### PR TITLE
카카오 OAuth 로그인 회원 인증 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application profiles ###
+application*.yml
+application.properties

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthProviderService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthProviderService.java
@@ -1,0 +1,7 @@
+package com.dnd.namuiwiki.application.oauth;
+
+import com.dnd.namuiwiki.application.oauth.dto.OAuthUserInfoDto;
+
+public interface OAuthProviderService {
+    OAuthUserInfoDto getOAuthUserInfo(String code);
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
@@ -1,0 +1,43 @@
+package com.dnd.namuiwiki.application.oauth;
+
+import com.dnd.namuiwiki.application.oauth.dto.KakaoOAuthTokenRequest;
+import com.dnd.namuiwiki.application.oauth.dto.KakaoOAuthTokenResponse;
+import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.presentation.auth.dto.OAuthLoginResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class OAuthService {
+
+    public OAuthLoginResponse oauthLogin(String provider, String code) {
+        switch (OAuthProvider.of(provider)) {
+            case KAKAO:
+                return oauthKakaoLogin(code);
+            default:
+                throw new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT, "지원하지 않는 프로바이더입니다.");
+        }
+    }
+
+
+    private OAuthLoginResponse oauthKakaoLogin(String code) {
+        ResponseEntity<KakaoOAuthTokenResponse> response = RestClient.create().post()
+                .uri(KakaoOAuthTokenRequest.requestTokenURL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(KakaoOAuthTokenRequest.from(code))
+                .retrieve()
+                .toEntity(KakaoOAuthTokenResponse.class);
+        System.out.println(response.getBody().getAccess_token());
+
+        /**
+         * TODO JWT 발급 후 반환
+         */
+        return null;// new OAuthLoginResponse(null, null);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
@@ -5,21 +5,25 @@ import com.dnd.namuiwiki.application.oauth.kakao.OAuthKakaoService;
 import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
-@RequiredArgsConstructor
 public class OAuthService {
-    private final OAuthKakaoService oAuthKakaoService;
+    private final Map<OAuthProvider, OAuthProviderService> providerServiceHandler = new HashMap<>();
+
+    public OAuthService(OAuthKakaoService oAuthKakaoService) {
+        providerServiceHandler.put(OAuthProvider.KAKAO, oAuthKakaoService);
+    }
 
     public OAuthUserInfoDto oauthLogin(String provider, String code) {
-        switch (OAuthProvider.of(provider)) {
-            case KAKAO:
-                return oAuthKakaoService.getOAuthUserInfo(code);
-            default:
-                throw new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT, "지원하지 않는 프로바이더입니다.");
+        OAuthProviderService providerService = providerServiceHandler.get(OAuthProvider.of(provider));
+        if (providerService == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT, "지원하지 않는 프로바이더입니다.");
         }
+        return providerService.getOAuthUserInfo(code);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/OAuthService.java
@@ -1,43 +1,25 @@
 package com.dnd.namuiwiki.application.oauth;
 
-import com.dnd.namuiwiki.application.oauth.dto.KakaoOAuthTokenRequest;
-import com.dnd.namuiwiki.application.oauth.dto.KakaoOAuthTokenResponse;
+import com.dnd.namuiwiki.application.oauth.dto.OAuthUserInfoDto;
+import com.dnd.namuiwiki.application.oauth.kakao.OAuthKakaoService;
 import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
-import com.dnd.namuiwiki.presentation.auth.dto.OAuthLoginResponse;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
 
 @Service
+@RequiredArgsConstructor
 public class OAuthService {
+    private final OAuthKakaoService oAuthKakaoService;
 
-    public OAuthLoginResponse oauthLogin(String provider, String code) {
+    public OAuthUserInfoDto oauthLogin(String provider, String code) {
         switch (OAuthProvider.of(provider)) {
             case KAKAO:
-                return oauthKakaoLogin(code);
+                return oAuthKakaoService.getOAuthUserInfo(code);
             default:
                 throw new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT, "지원하지 않는 프로바이더입니다.");
         }
-    }
-
-
-    private OAuthLoginResponse oauthKakaoLogin(String code) {
-        ResponseEntity<KakaoOAuthTokenResponse> response = RestClient.create().post()
-                .uri(KakaoOAuthTokenRequest.requestTokenURL)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .accept(MediaType.APPLICATION_JSON)
-                .body(KakaoOAuthTokenRequest.from(code))
-                .retrieve()
-                .toEntity(KakaoOAuthTokenResponse.class);
-        System.out.println(response.getBody().getAccess_token());
-
-        /**
-         * TODO JWT 발급 후 반환
-         */
-        return null;// new OAuthLoginResponse(null, null);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/dto/KakaoOAuthTokenRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/dto/KakaoOAuthTokenRequest.java
@@ -1,0 +1,53 @@
+package com.dnd.namuiwiki.application.oauth.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Component
+public class KakaoOAuthTokenRequest {
+
+    public static String requestTokenURL;
+    private static String grantType;
+    private static String clientId;
+    private static String redirectUri;
+    private static String clientSecret;
+
+    public static MultiValueMap<String, String> from(String code) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", grantType);
+        form.add("client_id", clientId);
+        form.add("redirect_uri", redirectUri);
+        form.add("client_secret", clientSecret);
+        form.add("code", code);
+
+        return form;
+    }
+
+    @Value("${oauth.kakao.request-token-url}")
+    public void setRequestTokenURL(String requestTokenURL) {
+        KakaoOAuthTokenRequest.requestTokenURL = requestTokenURL;
+    }
+
+    @Value("${oauth.kakao.grant-type}")
+    public void setGrantType(String grantType) {
+        KakaoOAuthTokenRequest.grantType = grantType;
+    }
+
+    @Value("${oauth.kakao.client-id}")
+    public void setClientId(String clientId) {
+        KakaoOAuthTokenRequest.clientId = clientId;
+    }
+
+    @Value("${oauth.kakao.redirect-uri}")
+    public void setRedirectUri(String redirectUri) {
+        KakaoOAuthTokenRequest.redirectUri = redirectUri;
+    }
+
+    @Value("${oauth.kakao.client-secret}")
+    public void setClientSecret(String clientSecret) {
+        KakaoOAuthTokenRequest.clientSecret = clientSecret;
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/dto/KakaoOAuthTokenResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/dto/KakaoOAuthTokenResponse.java
@@ -1,0 +1,20 @@
+package com.dnd.namuiwiki.application.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class KakaoOAuthTokenResponse {
+
+    private String token_type;
+    private String access_token;
+    private String id_token;
+    private Long expires_in;
+    private String refresh_token;
+    private Long refresh_token_expires_in;
+    private String scope;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/dto/OAuthUserInfoDto.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/dto/OAuthUserInfoDto.java
@@ -1,0 +1,14 @@
+package com.dnd.namuiwiki.application.oauth.dto;
+
+import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserInfoDto {
+
+    private OAuthProvider provider;
+    private String oAuthId;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/OAuthKakaoService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/OAuthKakaoService.java
@@ -4,6 +4,9 @@ import com.dnd.namuiwiki.application.oauth.OAuthProviderService;
 import com.dnd.namuiwiki.application.oauth.dto.OAuthUserInfoDto;
 import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthTokenRequest;
 import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthTokenResponse;
+import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthUserInfoRequest;
+import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthUserInfoResponse;
+import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import org.springframework.http.MediaType;
@@ -16,7 +19,8 @@ public class OAuthKakaoService implements OAuthProviderService {
     @Override
     public OAuthUserInfoDto getOAuthUserInfo(String code) {
         String accessToken = getAccessToken(code);
-        return null;
+        String oauthUserId = getOAuthUserId(accessToken);
+        return new OAuthUserInfoDto(OAuthProvider.KAKAO, oauthUserId);
     }
 
     private String getAccessToken(String code) {
@@ -34,6 +38,23 @@ public class OAuthKakaoService implements OAuthProviderService {
         }
 
         return tokenResponse.getAccess_token();
+    }
+
+    private String getOAuthUserId(String accessToken) {
+        KakaoOAuthUserInfoResponse userInfoResponse = RestClient.create().post()
+                .uri(KakaoOAuthUserInfoRequest.requestUserInfoURL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(KakaoOAuthUserInfoResponse.class)
+                .getBody();
+
+        if (userInfoResponse == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR);
+        }
+
+        return userInfoResponse.getId().toString();
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/OAuthKakaoService.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/OAuthKakaoService.java
@@ -1,0 +1,39 @@
+package com.dnd.namuiwiki.application.oauth.kakao;
+
+import com.dnd.namuiwiki.application.oauth.OAuthProviderService;
+import com.dnd.namuiwiki.application.oauth.dto.OAuthUserInfoDto;
+import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthTokenRequest;
+import com.dnd.namuiwiki.application.oauth.kakao.dto.KakaoOAuthTokenResponse;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class OAuthKakaoService implements OAuthProviderService {
+
+    @Override
+    public OAuthUserInfoDto getOAuthUserInfo(String code) {
+        String accessToken = getAccessToken(code);
+        return null;
+    }
+
+    private String getAccessToken(String code) {
+        KakaoOAuthTokenResponse tokenResponse = RestClient.create().post()
+                .uri(KakaoOAuthTokenRequest.requestTokenURL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(KakaoOAuthTokenRequest.from(code))
+                .retrieve()
+                .toEntity(KakaoOAuthTokenResponse.class)
+                .getBody();
+
+        if (tokenResponse == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR);
+        }
+
+        return tokenResponse.getAccess_token();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenRequest.java
@@ -1,4 +1,4 @@
-package com.dnd.namuiwiki.application.oauth.dto;
+package com.dnd.namuiwiki.application.oauth.kakao.dto;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenRequest.java
@@ -26,27 +26,27 @@ public class KakaoOAuthTokenRequest {
     }
 
     @Value("${oauth.kakao.request-token-url}")
-    public void setRequestTokenURL(String requestTokenURL) {
+    private void setRequestTokenURL(String requestTokenURL) {
         KakaoOAuthTokenRequest.requestTokenURL = requestTokenURL;
     }
 
     @Value("${oauth.kakao.grant-type}")
-    public void setGrantType(String grantType) {
+    private void setGrantType(String grantType) {
         KakaoOAuthTokenRequest.grantType = grantType;
     }
 
     @Value("${oauth.kakao.client-id}")
-    public void setClientId(String clientId) {
+    private void setClientId(String clientId) {
         KakaoOAuthTokenRequest.clientId = clientId;
     }
 
     @Value("${oauth.kakao.redirect-uri}")
-    public void setRedirectUri(String redirectUri) {
+    private void setRedirectUri(String redirectUri) {
         KakaoOAuthTokenRequest.redirectUri = redirectUri;
     }
 
     @Value("${oauth.kakao.client-secret}")
-    public void setClientSecret(String clientSecret) {
+    private void setClientSecret(String clientSecret) {
         KakaoOAuthTokenRequest.clientSecret = clientSecret;
     }
 

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthTokenResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.namuiwiki.application.oauth.dto;
+package com.dnd.namuiwiki.application.oauth.kakao.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoRequest.java
@@ -1,0 +1,16 @@
+package com.dnd.namuiwiki.application.oauth.kakao.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoOAuthUserInfoRequest {
+
+    public static String requestUserInfoURL;
+
+    @Value("${oauth.kakao.request-user-url}")
+    public void setRequestUserInfoURL(String requestUserInfoURL) {
+        KakaoOAuthUserInfoRequest.requestUserInfoURL = requestUserInfoURL;
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoRequest.java
@@ -9,7 +9,7 @@ public class KakaoOAuthUserInfoRequest {
     public static String requestUserInfoURL;
 
     @Value("${oauth.kakao.request-user-url}")
-    public void setRequestUserInfoURL(String requestUserInfoURL) {
+    private void setRequestUserInfoURL(String requestUserInfoURL) {
         KakaoOAuthUserInfoRequest.requestUserInfoURL = requestUserInfoURL;
     }
 

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/kakao/dto/KakaoOAuthUserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.dnd.namuiwiki.application.oauth.kakao.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class KakaoOAuthUserInfoResponse {
+
+    private Long id;
+    private Boolean has_signed_up;
+    private String connected_at;
+    private String synched_at;
+    private String properties;
+    private Object kakao_account;
+    private Object for_partner;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/application/oauth/type/OAuthProvider.java
+++ b/src/main/java/com/dnd/namuiwiki/application/oauth/type/OAuthProvider.java
@@ -1,0 +1,19 @@
+package com.dnd.namuiwiki.application.oauth.type;
+
+import lombok.Getter;
+
+@Getter
+public enum OAuthProvider {
+    KAKAO("KAKAO");
+
+    private String name;
+
+    private OAuthProvider(String name) {
+        this.name = name;
+    }
+
+    public static OAuthProvider of(String provider) {
+        return OAuthProvider.valueOf(provider.toUpperCase());
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/common/annotation/Enum.java
+++ b/src/main/java/com/dnd/namuiwiki/common/annotation/Enum.java
@@ -1,0 +1,26 @@
+package com.dnd.namuiwiki.common.annotation;
+
+import com.dnd.namuiwiki.common.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum {
+    String message() default "Invalid value. This is not permitted.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+
+    boolean ignoreCase() default false;
+}
+

--- a/src/main/java/com/dnd/namuiwiki/common/validator/EnumValidator.java
+++ b/src/main/java/com/dnd/namuiwiki/common/validator/EnumValidator.java
@@ -1,0 +1,32 @@
+package com.dnd.namuiwiki.common.validator;
+
+import com.dnd.namuiwiki.common.annotation.Enum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<Enum, String> {
+
+    private Enum annotation;
+
+    @Override
+    public void initialize(Enum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean result = false;
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())
+                        || (this.annotation.ignoreCase() && value.equalsIgnoreCase(enumValue.toString()))) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/presentation/auth/AuthController.java
+++ b/src/main/java/com/dnd/namuiwiki/presentation/auth/AuthController.java
@@ -1,0 +1,32 @@
+package com.dnd.namuiwiki.presentation.auth;
+
+import com.dnd.namuiwiki.application.oauth.OAuthService;
+import com.dnd.namuiwiki.application.oauth.dto.OAuthUserInfoDto;
+import com.dnd.namuiwiki.presentation.auth.dto.OAuthLoginRequest;
+import com.dnd.namuiwiki.presentation.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final OAuthService oAuthService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Validated @RequestBody OAuthLoginRequest request) {
+        OAuthUserInfoDto oauthUserInfo = oAuthService.oauthLogin(request.getProvider(), request.getCode());
+        /*
+        TODO
+        1. 유저 DB에 데이터 저장
+        2. jwt 발행
+         */
+        return ResponseDto.noContent();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/presentation/auth/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/presentation/auth/dto/OAuthLoginRequest.java
@@ -1,0 +1,20 @@
+package com.dnd.namuiwiki.presentation.auth.dto;
+
+import com.dnd.namuiwiki.application.oauth.type.OAuthProvider;
+import com.dnd.namuiwiki.common.annotation.Enum;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OAuthLoginRequest {
+
+    @NotEmpty
+    @Enum(enumClass = OAuthProvider.class, ignoreCase = true)
+    private final String provider;
+
+    @NotEmpty
+    private final String code;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/presentation/auth/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/presentation/auth/dto/OAuthLoginResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.namuiwiki.presentation.auth.dto;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OAuthLoginResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/presentation/dto/ResponseDto.java
+++ b/src/main/java/com/dnd/namuiwiki/presentation/dto/ResponseDto.java
@@ -1,0 +1,33 @@
+package com.dnd.namuiwiki.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseDto<T> implements Serializable {
+    private T data;
+
+    public static <T> ResponseEntity<ResponseDto<T>> ok(T data) {
+        return ResponseEntity.ok(new ResponseDto<T>(data));
+    }
+
+    public static <T> ResponseEntity<ResponseDto<T>> created(T data) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseDto<T>(data));
+    }
+
+    public static ResponseEntity<Void> noContent() {
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+}


### PR DESCRIPTION
It closes #1 

## 요약
1. 클라이언트에서 받은 카카오 OAuth `code`를 통해 `accessToken` 발급
2. `accessToken`을 통해 oauth ID 조회

## 변경된 점
- 컨트롤러에서 Enum을 Validation 할 수 있도록 Validator를 추가하였습니다.
- 추후에 다른 OAuth Provider가 추가될 수 있을 것 같아 OAuthService 인터페이스를 두었습니다.
  - KakaoOAuthService가 상속받았습니다.
  - `getOAuthUserInfo()`를 통해서 provider와 id를 받을 수 있습니다. **이 값들을 이용해서 JWT 발급 작업 진행하시면 될 것 같습니다.**
- API base endpoint를 `/api/v1` 으로 잡았습니다. 
- `KakaoOAuthToken*` 클래스들은 카카오 OAuth 로그인 스펙입니다. [관련 링크](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token)

## 특이 사항
- secret 값들이 들어가게 될 것 같아 application 프로퍼티 관련 파일을 gitignore 하였습니다. 파일은 따로 공유드리겠습니다. 혹시 시크릿값들을 이 방법외에 관리하는 더 좋은 방법이 있다면 의견 주세요! [세팅 파일](https://www.notion.so/eunseong/BE-9c7811dd2b28466682c1f4f414bbd43e?pvs=4)
- 🚨 dto 들을 어디에 관리해야 할 지 잘 모르겠어요... 지금 여기저기 산발되어 있는데, 컨벤션을 정해야 할 것 같습니다. 일단은 사용하는 패키지 하위에 `dto` 패키지 생성하여 그 아래 두었습니다.
- dto 네이밍 컨벤션이 필요합니다. 저는 HTTP 요청&응답에서 사용되는 DTO들은 이름 뒤에 `Request`와 `Response`를 붙이고, 그 외 객체 변환만 발생할 경우에는 `Dto`를 붙이는 방식으로 진행했습니다. 이것도 의견 주세요!


```
작업이 연속적으로 이루어져서 #2 의 커밋과 일부 겹칩니다. #3 이 머지된 후에 머지 브랜치를 dev 브랜치로 변경하겠습니다.
```