### PR TITLE
Jwt 추가 구현(#13)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/dto/ResponseDto.java
+++ b/src/main/java/com/dnd/namuiwiki/common/dto/ResponseDto.java
@@ -19,6 +19,11 @@ public class ResponseDto<T> implements Serializable {
         return ResponseEntity.ok(new ResponseDto<T>(data));
     }
 
+    public static ResponseEntity.BodyBuilder setCookie(String cookie) {
+        return ResponseEntity.ok()
+                .header("Set-Cookie", cookie);
+    }
+
     public static <T> ResponseEntity<ResponseDto<T>> created(T data) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/dnd/namuiwiki/common/exception/ApplicationErrorType.java
+++ b/src/main/java/com/dnd/namuiwiki/common/exception/ApplicationErrorType.java
@@ -28,8 +28,12 @@ public enum ApplicationErrorType {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
     AUTHORIZATION_FAILED(HttpStatus.FORBIDDEN, "인가에 실패하였습니다."),
     TOKEN_INTERNAL_ERROR(HttpStatus.UNAUTHORIZED, "토큰 verify 실패 (토큰 내부 값 오류)"),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 
+    /**
+     * User Error Type
+     */
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다.");
 
     @Getter
     private HttpStatus httpStatus;

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
@@ -1,0 +1,40 @@
+package com.dnd.namuiwiki.common.filter;
+
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.common.exception.dto.ErrorResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            ErrorResponseDto errorResponseDto = new ErrorResponseDto(ApplicationErrorType.AUTHENTICATION_FAILED.name(), e.getMessage());
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.getWriter().write(convertObjectToJson(errorResponseDto));
+        }
+    }
+
+    private String convertObjectToJson(Object object) throws JsonProcessingException {
+        if (object == null) {
+            return null;
+        }
+        return objectMapper.writeValueAsString(object);
+    }
+}

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
@@ -10,14 +10,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
+
+    private final List<String> excludeUrlPatterns;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -36,5 +41,11 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
             return null;
         }
         return objectMapper.writeValueAsString(object);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return excludeUrlPatterns.stream()
+                .anyMatch(p -> antPathMatcher.match(p, request.getServletPath()));
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtExceptionHandlerFilter.java
@@ -4,7 +4,6 @@ import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.common.exception.dto.ErrorResponseDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,9 +23,10 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (JwtException e) {
+        } catch (RuntimeException e) {
             ErrorResponseDto errorResponseDto = new ErrorResponseDto(ApplicationErrorType.AUTHENTICATION_FAILED.name(), e.getMessage());
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setCharacterEncoding("UTF-8");
             response.getWriter().write(convertObjectToJson(errorResponseDto));
         }
     }

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -9,12 +9,15 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 
+@Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -22,8 +25,10 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final List<String> excludeUrlPatterns;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    @Value("${jwt.authentication-header}")
+    private String AUTHENTICATION_HEADER;
     private final String HTTP_METHOD_OPTIONS = "OPTIONS";
-    private final String AUTHENTICATION_HEADER = "X-NAMUIWIKI-TOKEN";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -9,35 +9,24 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
 
-@Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
     private final String AUTHENTICATION_HEADER = "X-NAMUIWIKI-TOKEN";
-
-    @Value("${jwt.permit-uri}")
-    private List<String> permittedURIs;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (permittedURIs.stream().noneMatch(p -> antPathMatcher.match(p, request.getRequestURI()))) {
-            String authHeader = request.getHeader(AUTHENTICATION_HEADER);
-            if (authHeader == null) {
-                throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
-            }
-            Jws<Claims> claims = jwtProvider.validateToken(authHeader);
-            jwtProvider.parseToken(claims);
+        String authHeader = request.getHeader(AUTHENTICATION_HEADER);
+        if (authHeader == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
         }
+        Jws<Claims> claims = jwtProvider.validateToken(authHeader);
+        jwtProvider.parseToken(claims);
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -17,16 +17,19 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final String HTTP_METHOD_OPTIONS = "OPTIONS";
     private final String AUTHENTICATION_HEADER = "X-NAMUIWIKI-TOKEN";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String authHeader = request.getHeader(AUTHENTICATION_HEADER);
-        if (authHeader == null) {
-            throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
+        if (!request.getMethod().equals(HTTP_METHOD_OPTIONS)) {
+            String authHeader = request.getHeader(AUTHENTICATION_HEADER);
+            if (authHeader.isBlank()) {
+                throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
+            }
+            Jws<Claims> claims = jwtProvider.validateToken(authHeader);
+            jwtProvider.parseToken(claims);
         }
-        Jws<Claims> claims = jwtProvider.validateToken(authHeader);
-        jwtProvider.parseToken(claims);
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -4,20 +4,16 @@ import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.jwt.JwtProvider;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 
-@Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -26,8 +22,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final List<String> excludeUrlPatterns;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
-    @Value("${jwt.authentication-header}")
-    private String AUTHENTICATION_HEADER;
+    private final String AUTHENTICATION_HEADER;
     private final String HTTP_METHOD_OPTIONS = "OPTIONS";
 
     @Override

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -32,7 +32,7 @@ public class JwtFilter extends OncePerRequestFilter {
             if (authHeader == null) {
                 throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
             }
-            Jws<Claims> claims = jwtProvider.validateToken(authHeader);
+            Claims claims = jwtProvider.validateToken(authHeader);
             request.setAttribute("claims", claims);
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -33,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
             }
             Jws<Claims> claims = jwtProvider.validateToken(authHeader);
-            jwtProvider.parseToken(claims);
+            request.setAttribute("claims", claims);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -9,14 +9,19 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+
+    private final List<String> excludeUrlPatterns;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
     private final String HTTP_METHOD_OPTIONS = "OPTIONS";
     private final String AUTHENTICATION_HEADER = "X-NAMUIWIKI-TOKEN";
 
@@ -24,12 +29,18 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         if (!request.getMethod().equals(HTTP_METHOD_OPTIONS)) {
             String authHeader = request.getHeader(AUTHENTICATION_HEADER);
-            if (authHeader.isBlank()) {
+            if (authHeader == null) {
                 throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);
             }
             Jws<Claims> claims = jwtProvider.validateToken(authHeader);
             jwtProvider.parseToken(claims);
         }
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return excludeUrlPatterns.stream()
+                .anyMatch(p -> antPathMatcher.match(p, request.getServletPath()));
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
@@ -19,13 +19,16 @@ public class FilterConfiguration {
     @Value("${jwt.permit-uri}")
     private String[] permittedURIs;
 
+    @Value("${jwt.authentication-header}")
+    private String AUTHENTICATION_HEADER;
+
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
 
     @Bean
     public FilterRegistrationBean<JwtFilter> jwtFilter() {
         FilterRegistrationBean<JwtFilter> jwtFilterBean = new FilterRegistrationBean<>();
-        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, List.of(permittedURIs)));
+        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, List.of(permittedURIs), AUTHENTICATION_HEADER));
         jwtFilterBean.setOrder(2);
         return jwtFilterBean;
     }

--- a/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
@@ -1,0 +1,39 @@
+package com.dnd.namuiwiki.config;
+
+import com.dnd.namuiwiki.common.filter.JwtExceptionHandlerFilter;
+import com.dnd.namuiwiki.common.filter.JwtFilter;
+import com.dnd.namuiwiki.domain.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfiguration {
+
+    @Value("${jwt.permit-uri}")
+    private String[] permittedURIs;
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public FilterRegistrationBean<JwtFilter> jwtFilter() {
+        FilterRegistrationBean<JwtFilter> jwtFilterBean = new FilterRegistrationBean<>();
+        jwtFilterBean.setFilter(new JwtFilter(jwtProvider));
+        jwtFilterBean.addUrlPatterns(permittedURIs);
+        jwtFilterBean.setOrder(2);
+        return jwtFilterBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtExceptionHandlerFilter> jwtExceptionHandlerFilter() {
+        FilterRegistrationBean<JwtExceptionHandlerFilter> jwtExceptionHandlerFilterBean = new FilterRegistrationBean<>();
+        jwtExceptionHandlerFilterBean.setFilter(new JwtExceptionHandlerFilter(objectMapper));
+        jwtExceptionHandlerFilterBean.setOrder(1);
+        return jwtExceptionHandlerFilterBean;
+    }
+}

--- a/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
@@ -10,12 +10,14 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 @RequiredArgsConstructor
 public class FilterConfiguration {
 
     @Value("${jwt.permit-uri}")
-    private String[] permittedURIs;
+    private List<String > permittedURIs;
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
@@ -23,8 +25,7 @@ public class FilterConfiguration {
     @Bean
     public FilterRegistrationBean<JwtFilter> jwtFilter() {
         FilterRegistrationBean<JwtFilter> jwtFilterBean = new FilterRegistrationBean<>();
-        jwtFilterBean.setFilter(new JwtFilter(jwtProvider));
-        jwtFilterBean.addUrlPatterns(permittedURIs);
+        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, permittedURIs));
         jwtFilterBean.setOrder(2);
         return jwtFilterBean;
     }

--- a/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class FilterConfiguration {
 
     @Value("${jwt.permit-uri}")
-    private List<String > permittedURIs;
+    private String[] permittedURIs;
 
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
@@ -25,7 +25,7 @@ public class FilterConfiguration {
     @Bean
     public FilterRegistrationBean<JwtFilter> jwtFilter() {
         FilterRegistrationBean<JwtFilter> jwtFilterBean = new FilterRegistrationBean<>();
-        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, permittedURIs));
+        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, List.of(permittedURIs)));
         jwtFilterBean.setOrder(2);
         return jwtFilterBean;
     }
@@ -33,7 +33,7 @@ public class FilterConfiguration {
     @Bean
     public FilterRegistrationBean<JwtExceptionHandlerFilter> jwtExceptionHandlerFilter() {
         FilterRegistrationBean<JwtExceptionHandlerFilter> jwtExceptionHandlerFilterBean = new FilterRegistrationBean<>();
-        jwtExceptionHandlerFilterBean.setFilter(new JwtExceptionHandlerFilter(objectMapper));
+        jwtExceptionHandlerFilterBean.setFilter(new JwtExceptionHandlerFilter(objectMapper, List.of(permittedURIs)));
         jwtExceptionHandlerFilterBean.setOrder(1);
         return jwtExceptionHandlerFilterBean;
     }

--- a/src/main/java/com/dnd/namuiwiki/config/WebConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/WebConfiguration.java
@@ -1,11 +1,17 @@
 package com.dnd.namuiwiki.config;
 
+import com.dnd.namuiwiki.domain.jwt.JwtAuthorizationArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfiguration implements WebMvcConfigurer {
 
     @Value("${spring.cors.allowed-origins}")
@@ -17,6 +23,8 @@ public class WebConfiguration implements WebMvcConfigurer {
     @Value("${spring.cors.allowed-headers}")
     private String[] allowedHeaders;
 
+    private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -24,5 +32,10 @@ public class WebConfiguration implements WebMvcConfigurer {
                 .allowedMethods(allowedMethods)
                 .allowedHeaders(allowedHeaders)
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(jwtAuthorizationArgumentResolver);
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
@@ -14,6 +14,7 @@ import com.dnd.namuiwiki.common.dto.ResponseDto;
 import com.dnd.namuiwiki.domain.user.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    @Value("${jwt.authentication-header}")
+    private String AUTHENTICATION_HEADER;
+
     private final OAuthService oAuthService;
     private final UserService userService;
     private final JwtService jwtService;
@@ -40,7 +45,7 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(HttpServletRequest request, @CookieValue("refreshToken") String refreshToken) {
-        String accessToken = request.getHeader("X-NAMUIWIKI-TOKEN");
+        String accessToken = request.getHeader(AUTHENTICATION_HEADER);
 
         if (accessToken == null) {
             throw new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_ACCESS_TOKEN);

--- a/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
@@ -1,5 +1,7 @@
 package com.dnd.namuiwiki.domain.auth;
 
+import com.dnd.namuiwiki.domain.jwt.JwtAuthorization;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import com.dnd.namuiwiki.domain.oauth.OAuthService;
 import com.dnd.namuiwiki.domain.oauth.dto.OAuthUserInfoDto;
 import com.dnd.namuiwiki.domain.auth.dto.OAuthLoginRequest;
@@ -9,10 +11,7 @@ import com.dnd.namuiwiki.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -31,6 +30,11 @@ public class AuthController {
          */
         OAuthLoginResponse oAuthLoginResponse = userService.login(oauthUserInfo);
         return ResponseDto.ok(oAuthLoginResponse);
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<?> test(@JwtAuthorization TokenUserInfoDto tokenUserInfoDto) {
+        return null;
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/auth/AuthController.java
@@ -26,6 +26,7 @@ public class AuthController {
 
     @Value("${jwt.authentication-header}")
     private String AUTHENTICATION_HEADER;
+    private final String REFRESH_TOKEN_COOKIE = "refreshToken=%s; secure";
 
     private final OAuthService oAuthService;
     private final UserService userService;
@@ -40,7 +41,8 @@ public class AuthController {
         2. jwt 발행
          */
         OAuthLoginResponse oAuthLoginResponse = userService.login(oauthUserInfo);
-        return ResponseDto.ok(oAuthLoginResponse);
+        return ResponseDto.setCookie(String.format(REFRESH_TOKEN_COOKIE, oAuthLoginResponse.getRefreshToken()))
+                .body(oAuthLoginResponse);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/dnd/namuiwiki/domain/auth/dto/RefreshResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/auth/dto/RefreshResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.namuiwiki.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorization.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorization.java
@@ -1,0 +1,9 @@
+package com.dnd.namuiwiki.domain.jwt;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JwtAuthorization {
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
@@ -31,14 +31,14 @@ public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentRe
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        if (request != null) {
-            Claims claims = (Claims) request.getAttribute("claims");
-            TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claims);
-            String wikiId = tokenUserInfoDto.getWikiId();
-            User user = userRepository.findByWikiId(wikiId)
-                    .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_AUTHORITY_DATA));
-            return new TokenUserInfoDto(user.getWikiId());
+        if (request == null) {
+            throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
         }
-        throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
+        Claims claims = (Claims) request.getAttribute("claims");
+        TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claims);
+        String wikiId = tokenUserInfoDto.getWikiId();
+        User user = userRepository.findByWikiId(wikiId)
+                .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_AUTHORITY_DATA));
+        return new TokenUserInfoDto(user.getWikiId());
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.dnd.namuiwiki.domain.jwt;
+
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
+import com.dnd.namuiwiki.domain.user.UserRepository;
+import com.dnd.namuiwiki.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(JwtAuthorization.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request != null) {
+            Jws<Claims> claims = (Jws<Claims>) request.getAttribute("claims");
+            TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claims);
+            String wikiId = tokenUserInfoDto.getWikiId();
+            User user = userRepository.findByWikiId(wikiId)
+                    .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_AUTHORITY_DATA));
+            return new TokenUserInfoDto(user.getWikiId());
+        }
+        throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
+    }
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtAuthorizationArgumentResolver.java
@@ -32,7 +32,7 @@ public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentRe
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         if (request != null) {
-            Jws<Claims> claims = (Jws<Claims>) request.getAttribute("claims");
+            Claims claims = (Claims) request.getAttribute("claims");
             TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claims);
             String wikiId = tokenUserInfoDto.getWikiId();
             User user = userRepository.findByWikiId(wikiId)

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
@@ -6,6 +6,7 @@ import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,7 @@ import javax.crypto.SecretKey;
 import java.util.Date;
 
 @Component
-public class JwtProvider implements InitializingBean {
+public class JwtProvider {
 
     @Value("${jwt.key}")
     public String key;
@@ -27,7 +28,7 @@ public class JwtProvider implements InitializingBean {
     private final String WIKI_ID = "WIKI_ID";
     private SecretKey secretKey;
 
-    @Override
+    @PostConstruct
     public void afterPropertiesSet() {
         byte[] keyBytes = Decoders.BASE64.decode(key);
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
@@ -72,6 +72,8 @@ public class JwtProvider {
                     .verifyWith(secretKey)
                     .build()
                     .parseSignedClaims(token);
+        } catch (ExpiredJwtException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.EXPIRED_TOKEN);
         } catch (JwtException e) {
             throw new ApplicationErrorException(ApplicationErrorType.AUTHENTICATION_FAILED);
         }

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtProvider.java
@@ -79,6 +79,21 @@ public class JwtProvider {
         }
     }
 
+    public boolean isExpiredToken(String token) {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+        } catch (ExpiredJwtException e) {
+            return true;
+        } catch (JwtException e) {
+            throw new ApplicationErrorException(ApplicationErrorType.AUTHENTICATION_FAILED);
+        }
+        return false;
+    }
+
     public TokenUserInfoDto parseToken(Jws<Claims> jwt) {
         Claims claims = jwt.getPayload();
         String wikiId = claims.get(WIKI_ID, String.class);

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtService.java
@@ -1,6 +1,17 @@
 package com.dnd.namuiwiki.domain.jwt;
 
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.auth.dto.OAuthLoginResponse;
+import com.dnd.namuiwiki.domain.auth.dto.RefreshResponse;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
+import com.dnd.namuiwiki.domain.user.UserRepository;
+import com.dnd.namuiwiki.domain.user.UserService;
+import com.dnd.namuiwiki.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,12 +19,32 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JwtService {
 
-
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     public OAuthLoginResponse issueTokenPair(String wikiId) {
         String accessToken = jwtProvider.createAccessToken(wikiId);
         String refreshToken = jwtProvider.createRefreshToken();
         return new OAuthLoginResponse(accessToken, refreshToken);
+    }
+
+    public RefreshResponse reIssueToken(String accessToken, String refreshToken) {
+
+        if(!jwtProvider.isExpiredToken(accessToken)) {
+            throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
+        }
+
+        Jws<Claims> claimsJws = jwtProvider.validateToken(refreshToken);
+        TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claimsJws);
+
+        String wikiId = tokenUserInfoDto.getWikiId();
+        User user = userRepository.findByWikiId(wikiId)
+                .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
+
+        if(!user.getRefreshToken().equals(refreshToken)) {
+            throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
+        }
+
+        return new RefreshResponse(jwtProvider.createAccessToken(wikiId));
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/jwt/JwtService.java
@@ -29,15 +29,9 @@ public class JwtService {
     }
 
     public RefreshResponse reIssueToken(String accessToken, String refreshToken) {
+        String wikiId = jwtProvider.parseExpiredToken(accessToken).getWikiId();
+        jwtProvider.validateToken(refreshToken);
 
-        if(!jwtProvider.isExpiredToken(accessToken)) {
-            throw new ApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
-        }
-
-        Jws<Claims> claimsJws = jwtProvider.validateToken(refreshToken);
-        TokenUserInfoDto tokenUserInfoDto = jwtProvider.parseToken(claimsJws);
-
-        String wikiId = tokenUserInfoDto.getWikiId();
         User user = userRepository.findByWikiId(wikiId)
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
 

--- a/src/main/java/com/dnd/namuiwiki/domain/oauth/kakao/dto/KakaoOAuthUserInfoResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/oauth/kakao/dto/KakaoOAuthUserInfoResponse.java
@@ -13,7 +13,7 @@ public class KakaoOAuthUserInfoResponse {
     private Boolean has_signed_up;
     private String connected_at;
     private String synched_at;
-    private String properties;
+    private Object properties;
     private Object kakao_account;
     private Object for_partner;
 

--- a/src/main/java/com/dnd/namuiwiki/domain/user/UserRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/UserRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.Optional;
 
 public interface UserRepository extends MongoRepository<User, String> {
-    Optional<User> findByOAuthProviderAndOAuthId(OAuthProvider oAuthProvider, String oAuthId);
+    Optional<User> findByOauthProviderAndOauthId(OAuthProvider oauthProvider, String oauthId);
     Optional<User> findByWikiId(String wikiId);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/user/UserRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> findByOAuthProviderAndOAuthId(OAuthProvider oAuthProvider, String oAuthId);
+    Optional<User> findByWikiId(String wikiId);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/user/UserService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/UserService.java
@@ -17,7 +17,7 @@ public class UserService {
 
     @Transactional
     public OAuthLoginResponse login(OAuthUserInfoDto oAuthUserInfoDto) {
-        User user = userRepository.findByOAuthProviderAndOAuthId(oAuthUserInfoDto.getProvider(), oAuthUserInfoDto.getOAuthId())
+        User user = userRepository.findByOauthProviderAndOauthId(oAuthUserInfoDto.getProvider(), oAuthUserInfoDto.getOAuthId())
                 .orElseGet(() -> {
                     User newUser = new User(oAuthUserInfoDto.getProvider(), oAuthUserInfoDto.getOAuthId());
                     return userRepository.save(newUser);

--- a/src/main/java/com/dnd/namuiwiki/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/entity/User.java
@@ -13,14 +13,14 @@ public class User {
     @Id
     private String id;
     private String wikiId;
-    private OAuthProvider oAuthProvider;
-    private String oAuthId;
+    private OAuthProvider oauthProvider;
+    private String oauthId;
     private String refreshToken;
 
     public User(OAuthProvider oAuthProvider, String oAuthId) {
         this.wikiId = UUID.randomUUID().toString();
-        this.oAuthProvider = oAuthProvider;
-        this.oAuthId = oAuthId;
+        this.oauthProvider = oAuthProvider;
+        this.oauthId = oAuthId;
     }
 
     public void setRefreshToken(String refreshToken) {

--- a/src/test/java/com/dnd/namuiwiki/jwt/JwtProviderTest.java
+++ b/src/test/java/com/dnd/namuiwiki/jwt/JwtProviderTest.java
@@ -50,7 +50,7 @@ class JwtProviderTest {
     void parseToken() {
         //given
         String token = jwtProvider.createAccessToken(wikiId);
-        Jws<Claims> claims = jwtProvider.validateToken(token);
+        Claims claims = jwtProvider.validateToken(token);
 
         //when
         TokenUserInfoDto parsed = jwtProvider.parseToken(claims);


### PR DESCRIPTION
## 요약
- filter에서의 에러 핸들링
- 필터 이후 토큰 정보 활용
- refresh 구현

## 변경된 점
- filter에서의 에러 핸들링
  - jwtfilter에서의 에러 핸들링을 위해 jwtExceptionHandlerFilter를 추가했습니다.
- 필터 이후 토큰 정보 활용
  - 필터를 거친 후 토큰 정보를 활용하기 위해 ArgumentResolver를 이용했습니다.
  - 컨트롤러에서 파라미터에 @JwtAuthorization을 사용해 사용할 수 있습니다.
- refresh 구현
  - accessToken에 대한 유효성을 검사한 뒤, claim을 획득
  - db에 저장된 유저의 refreshToken과 쿠키의 refreshToken 비교

## 특이 사항

