### PR TITLE
대시 보드 조회 API

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/converter/EnumConverterFactory.java
+++ b/src/main/java/com/dnd/namuiwiki/common/converter/EnumConverterFactory.java
@@ -1,0 +1,28 @@
+package com.dnd.namuiwiki.common.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnumConverterFactory implements ConverterFactory<String, Enum> {
+
+    @Override
+    public <T extends Enum> Converter<String, T> getConverter(Class<T> targetType) {
+        return new StringToEnumsConverter<>(targetType);
+    }
+
+    private static final class StringToEnumsConverter<T extends Enum> implements Converter<String, T> {
+
+        private final Class<T> enumType;
+
+        public StringToEnumsConverter(Class<T> enumType) {
+            this.enumType = enumType;
+        }
+
+        @Override
+        public T convert(String source) {
+            return (T) Enum.valueOf(this.enumType, source.trim());
+        }
+    }
+}

--- a/src/main/java/com/dnd/namuiwiki/config/WebConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/WebConfiguration.java
@@ -1,9 +1,11 @@
 package com.dnd.namuiwiki.config;
 
+import com.dnd.namuiwiki.common.converter.EnumConverterFactory;
 import com.dnd.namuiwiki.domain.jwt.JwtAuthorizationArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -24,6 +26,7 @@ public class WebConfiguration implements WebMvcConfigurer {
     private String[] allowedHeaders;
 
     private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+    private final EnumConverterFactory enumConverterFactory;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -38,4 +41,10 @@ public class WebConfiguration implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(jwtAuthorizationArgumentResolver);
     }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverterFactory(enumConverterFactory);
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardController.java
@@ -1,0 +1,31 @@
+package com.dnd.namuiwiki.domain.dashboard;
+
+import com.dnd.namuiwiki.common.dto.ResponseDto;
+import com.dnd.namuiwiki.domain.jwt.JwtAuthorization;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+    private final DashboardService dashboardService;
+
+    @GetMapping
+    public ResponseEntity<?> getDashboard(
+            @JwtAuthorization TokenUserInfoDto tokenUserInfoDto,
+            @RequestParam(required = false) Period period,
+            @RequestParam(required = false) Relation relation
+    ) {
+        var response = dashboardService.getDashboard(tokenUserInfoDto, period, relation);
+        return ResponseDto.ok(response);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
@@ -1,6 +1,6 @@
 package com.dnd.namuiwiki.domain.dashboard;
 
-import com.dnd.namuiwiki.domain.statistic.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.entity.User;

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -1,0 +1,49 @@
+package com.dnd.namuiwiki.domain.dashboard;
+
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.dto.DashboardDto;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
+import com.dnd.namuiwiki.domain.statistic.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.user.UserRepository;
+import com.dnd.namuiwiki.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+    private final UserRepository userRepository;
+    private final DashboardRepository dashboardRepository;
+
+    public DashboardDto getDashboard(TokenUserInfoDto tokenUserInfoDto, Period period, Relation relation) {
+        validateFilterCategory(period, relation);
+
+        User user = findByWikiId(tokenUserInfoDto.getWikiId());
+        Optional<Dashboard> dashboard = dashboardRepository.findByUserAndPeriodAndRelation(user, period, relation);
+        if (dashboard.isEmpty()) {
+            return null;
+        }
+
+        List<DashboardComponent> dashboardComponents = dashboard.get().getDashboardComponents();
+        return new DashboardDto(dashboardComponents);
+    }
+
+    private void validateFilterCategory(Period period, Relation relation) {
+        if (period != null && relation != null) {
+            throw new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT);
+        }
+    }
+
+    private User findByWikiId(String wikiId) {
+        return userRepository.findByWikiId(wikiId)
+                .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -5,7 +5,7 @@ import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.dto.DashboardDto;
 import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
-import com.dnd.namuiwiki.domain.statistic.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.UserRepository;

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
@@ -1,0 +1,33 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class BestWorthDashboardComponent extends DashboardComponent {
+    private List<RatioDto> rank;
+
+    public BestWorthDashboardComponent(Statistics statistics) {
+        super(DashboardType.BEST_WORTH);
+        calculate(statistics);
+    }
+
+    @Override
+    public void calculate(Statistics statistics) {
+        RatioStatistic bestWorth = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType)
+                .getFirst();
+        Long totalCount = bestWorth.getTotalCount();
+        this.rank = bestWorth.getLegends().stream()
+                .map(legend -> {
+                    int percentage = (int) (legend.getCount() * 100 / totalCount);
+                    return new RatioDto(legend.getText(), percentage);
+                })
+                .toList();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/CharacterDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/CharacterDashboardComponent.java
@@ -1,0 +1,65 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.statistic.model.Legend;
+import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CharacterDashboardComponent extends DashboardComponent {
+
+    private boolean friendly;
+    private boolean similar;
+    private boolean mbti;
+    private boolean busy;
+
+    public CharacterDashboardComponent(Statistics statistics) {
+        super(DashboardType.CHARACTER);
+        calculate(statistics);
+    }
+
+    @Override
+    public void calculate(Statistics statistics) {
+        List<Statistic> character = statistics.getStatisticsByDashboardType(this.dashboardType);
+        character.forEach(statistic -> {
+            RatioStatistic ratioStatistic = (RatioStatistic) statistic;
+            List<Legend> legends = ratioStatistic.getLegends();
+            QuestionName questionName = ratioStatistic.getQuestionName();
+
+            switch (questionName) {
+                case FRIENDLINESS_LEVEL:
+                    this.friendly = getLegendByValue(legends, true).getCount() >=
+                            getLegendByValue(legends, false).getCount();
+                    break;
+                case PERSONALITY_TYPE:
+                    this.similar = getLegendByValue(legends, true).getCount() >=
+                            getLegendByValue(legends, false).getCount();
+                    break;
+                case MBTI_IMMERSION:
+                    this.mbti = getLegendByValue(legends, true).getCount() >=
+                            getLegendByValue(legends, false).getCount();
+                    break;
+                case WEEKEND_COMMITMENTS:
+                    this.busy = getLegendByValue(legends, true).getCount() >=
+                            getLegendByValue(legends, false).getCount();
+                    break;
+                default:
+                    break;
+            }
+        });
+    }
+
+    private Legend getLegendByValue(List<Legend> legends, boolean value) {
+        return legends.stream()
+                .filter(legend -> value == (boolean) legend.getValue())
+                .findFirst().orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR));
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/DashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/DashboardComponent.java
@@ -1,0 +1,16 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public abstract class DashboardComponent {
+
+    protected final DashboardType dashboardType;
+
+    public abstract void calculate(Statistics statistics);
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
@@ -1,0 +1,33 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class HappyDashboardComponent extends DashboardComponent {
+    private List<RatioDto> rank;
+
+    public HappyDashboardComponent(Statistics statistics) {
+        super(DashboardType.HAPPY);
+        calculate(statistics);
+    }
+
+    @Override
+    public void calculate(Statistics statistics) {
+        RatioStatistic happy = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType)
+                .getFirst();
+        Long totalCount = happy.getTotalCount();
+        this.rank = happy.getLegends().stream()
+                .map(legend -> {
+                    int percentage = (int) (legend.getCount() * 100 / totalCount);
+                    return new RatioDto(legend.getText(), percentage);
+                })
+                .toList();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
@@ -1,0 +1,27 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.AverageStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.Getter;
+
+@Getter
+public class MoneyDashboardComponent extends DashboardComponent {
+    private long peopleCount;
+    private long moneySum;
+    private long average;
+
+    public MoneyDashboardComponent(Statistics statistics) {
+        super(DashboardType.MONEY);
+        calculate(statistics);
+    }
+
+    @Override
+    public void calculate(Statistics statistics) {
+        AverageStatistic money = (AverageStatistic) statistics.getStatisticsByDashboardType(this.dashboardType)
+                .getFirst();
+        this.peopleCount = money.getTotalCount();
+        this.moneySum = money.getTotalSum();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
@@ -1,0 +1,33 @@
+package com.dnd.namuiwiki.domain.dashboard.model;
+
+import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SadDashboardComponent extends DashboardComponent {
+    private List<RatioDto> rank;
+
+    public SadDashboardComponent(Statistics statistics) {
+        super(DashboardType.HAPPY);
+        calculate(statistics);
+    }
+
+    @Override
+    public void calculate(Statistics statistics) {
+        RatioStatistic sad = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType)
+                .getFirst();
+        Long totalCount = sad.getTotalCount();
+        this.rank = sad.getLegends().stream()
+                .map(legend -> {
+                    int percentage = (int) (legend.getCount() * 100 / totalCount);
+                    return new RatioDto(legend.getText(), percentage);
+                })
+                .toList();
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
@@ -13,7 +13,7 @@ public class SadDashboardComponent extends DashboardComponent {
     private List<RatioDto> rank;
 
     public SadDashboardComponent(Statistics statistics) {
-        super(DashboardType.HAPPY);
+        super(DashboardType.SAD);
         calculate(statistics);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/DashboardDto.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/DashboardDto.java
@@ -1,0 +1,13 @@
+package com.dnd.namuiwiki.domain.dashboard.model.dto;
+
+import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class DashboardDto {
+    private List<DashboardComponent> statistics;
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/GetDashboardRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/GetDashboardRequest.java
@@ -1,0 +1,17 @@
+package com.dnd.namuiwiki.domain.dashboard.model.dto;
+
+import com.dnd.namuiwiki.common.annotation.Enum;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import lombok.Getter;
+
+@Getter
+public class GetDashboardRequest {
+
+    @Enum(enumClass = Period.class)
+    private String period;
+
+    @Enum(enumClass = Relation.class)
+    private String relation;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/RatioDto.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/RatioDto.java
@@ -1,0 +1,11 @@
+package com.dnd.namuiwiki.domain.dashboard.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class RatioDto {
+    private final String legend;
+    private final int percentage;
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
@@ -1,4 +1,4 @@
-package com.dnd.namuiwiki.domain.statistic.model.entity;
+package com.dnd.namuiwiki.domain.dashboard.model.entity;
 
 import com.dnd.namuiwiki.domain.dashboard.model.BestWorthDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.CharacterDashboardComponent;

--- a/src/main/java/com/dnd/namuiwiki/domain/option/OptionRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/option/OptionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.Optional;
 
 public interface OptionRepository extends MongoRepository<Option, String> {
-    Optional<Option> findByValue(Object value);
+    Optional<Option> findByText(String text);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -2,7 +2,7 @@ package com.dnd.namuiwiki.domain.statistic;
 
 import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
-import com.dnd.namuiwiki.domain.statistic.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Legend.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Legend.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class Legend {
     private String optionId;
     private String text;
+    private Object value;
     private Long count;
 
     public Long increaseCount() {

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/RatioStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/RatioStatistic.java
@@ -9,6 +9,7 @@ import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -30,9 +31,13 @@ public class RatioStatistic extends Statistic {
         return Optional.ofNullable(legends.get(optionId));
     }
 
+    public List<Legend> getLegends() {
+        return legends.values().stream().toList();
+    }
+
     public static RatioStatistic create(Question question) {
         Map<String, Legend> legends = new HashMap<>();
-        question.getOptions().forEach((key, value) -> legends.put(key, new Legend(key, value.getText(), 0L)));
+        question.getOptions().forEach((key, value) -> legends.put(key, new Legend(key, value.getText(), value.getValue(), 0L)));
         return new RatioStatistic(
                 question.getId(),
                 question.getName(),
@@ -54,7 +59,7 @@ public class RatioStatistic extends Statistic {
                 .orElseGet(() -> {
                     Option option = question.getOption(optionId)
                             .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_OPTION_ID));
-                    return new Legend(option.getId(), option.getText(), 0L);
+                    return new Legend(option.getId(), option.getText(), option.getValue(), 0L);
                 });
         legend.increaseCount();
     }

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistics.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistics.java
@@ -1,5 +1,6 @@
 package com.dnd.namuiwiki.domain.statistic.model;
 
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
 import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.statistic.type.StatisticsType;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
@@ -18,7 +19,9 @@ public class Statistics {
 
     public Statistic createAndPut(Question question) {
         StatisticsType statisticsType = question.getDashboardType().getStatisticsType();
-        return statistics.put(question.getId(), Statistic.create(question, statisticsType));
+        Statistic statistic = Statistic.create(question, statisticsType);
+        statistics.put(question.getId(), statistic);
+        return statistic;
     }
 
     public Optional<Statistic> get(String questionId) {
@@ -32,6 +35,12 @@ public class Statistics {
 
             statistic.updateStatistic(answer);
         });
+    }
+
+    public List<Statistic> getStatisticsByDashboardType(DashboardType dashboardType) {
+        return statistics.values().stream()
+                .filter(statistic -> statistic.getDashboardType().equals(dashboardType))
+                .toList();
     }
 
     public static Statistics from(List<Question> questions) {

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/entity/Dashboard.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/entity/Dashboard.java
@@ -1,5 +1,11 @@
 package com.dnd.namuiwiki.domain.statistic.model.entity;
 
+import com.dnd.namuiwiki.domain.dashboard.model.BestWorthDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.CharacterDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.HappyDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.MoneyDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.SadDashboardComponent;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import com.dnd.namuiwiki.domain.survey.type.Period;
@@ -32,6 +38,16 @@ public class Dashboard {
 
     public void updateStatistics(List<Survey.Answer> answer) {
         statistics.updateStatistics(answer);
+    }
+
+    public List<DashboardComponent> getDashboardComponents() {
+        return List.of(
+                new BestWorthDashboardComponent(statistics),
+                new HappyDashboardComponent(statistics),
+                new SadDashboardComponent(statistics),
+                new CharacterDashboardComponent(statistics),
+                new MoneyDashboardComponent(statistics)
+        );
     }
 
 }

--- a/src/main/resources/json/base-document.json
+++ b/src/main/resources/json/base-document.json
@@ -104,7 +104,7 @@
       "name":  "FIRST_IMPRESSION"
     },
     {
-      "title": "{{userName}}님을<br/><b>5글자(떠오르는 단어)로 표현</b>한다면?",
+      "title": "{{userName}}님을<br/><b>5글자로 표현</b>한다면?",
       "surveyOrder": 10,
       "type": "SHORT_ANSWER",
       "dashboardType": "NONE",
@@ -132,7 +132,7 @@
       "name":  "SECRET_PLEASURE"
     },
     {
-      "title": "{{userName}}님을 보면<br/><b>어떤 캐릭터(연예인)</b>이 떠오르나요?",
+      "title": "{{userName}}님을 보면<br/><b>어떤 캐릭터(연예인)</b>가 떠오르나요?",
       "surveyOrder": 14,
       "type": "SHORT_ANSWER",
       "dashboardType": "NONE",


### PR DESCRIPTION
it closes #32 
이 PR은 #31 이 머지된 후 머지됩니다.

## 요약
대시 보드 조회 api 구현

## 변경된 점
- Enum Converter 추가했습니다. Controller에서 argument를 받을 때 Enum 으로 받을 수 있습니다.
- Legend 클래스에 value 필드 추가했습니다. 2지선다(OX)의 옵션 타입을 boolean으로 변경하였습니다.
- 대시보드 컴포넌트 : 대시보드 타입의 객체입니다.
- 대시보드 컴포넌트별로 클래스 정의하였습니다. 부모믐 DashboardComponent입니다.

## 특이 사항

