### PR TITLE
전체 통계량 필요한 대시보드 계산 기능 추가(#38)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/util/ArithmeticUtils.java
+++ b/src/main/java/com/dnd/namuiwiki/common/util/ArithmeticUtils.java
@@ -1,0 +1,14 @@
+package com.dnd.namuiwiki.common.util;
+
+public class ArithmeticUtils {
+
+    public static long calculateAverage(long count, long average, long newNumber) {
+        if (count == 0) {
+            return newNumber;
+        }
+        double a = (double) count / (count + 1);
+        long b = average + newNumber / count;
+        return (long) (a * b);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -31,7 +31,14 @@ public class DashboardService {
             return null;
         }
 
-        List<DashboardComponent> dashboardComponents = dashboard.get().getDashboardComponents();
+        Statistics statistics = dashboard.get().getStatistics();
+        List<DashboardComponent> dashboardComponents = List.of(
+                new BestWorthDashboardComponent(statistics),
+                new HappyDashboardComponent(statistics),
+                new SadDashboardComponent(statistics),
+                new CharacterDashboardComponent(statistics),
+                getMoneyDashboardComponent(statistics, period, relation)
+        );
         return new DashboardDto(dashboardComponents);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -2,10 +2,20 @@ package com.dnd.namuiwiki.domain.dashboard;
 
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.domain.dashboard.model.BestWorthDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.CharacterDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.HappyDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.MoneyDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.SadDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.dto.DashboardDto;
-import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.statistic.StatisticsService;
+import com.dnd.namuiwiki.domain.statistic.model.BorrowingLimitEntireStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import com.dnd.namuiwiki.domain.statistic.model.entity.PopulationStatistic;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.UserRepository;
@@ -21,6 +31,7 @@ import java.util.Optional;
 public class DashboardService {
     private final UserRepository userRepository;
     private final DashboardRepository dashboardRepository;
+    private final StatisticsService statisticsService;
 
     public DashboardDto getDashboard(TokenUserInfoDto tokenUserInfoDto, Period period, Relation relation) {
         validateFilterCategory(period, relation);
@@ -40,6 +51,14 @@ public class DashboardService {
                 getMoneyDashboardComponent(statistics, period, relation)
         );
         return new DashboardDto(dashboardComponents);
+    }
+
+    private MoneyDashboardComponent getMoneyDashboardComponent(Statistics statistics, Period period, Relation relation) {
+        PopulationStatistic populationStatistic = statisticsService.getPopulationStatistic(period, relation, QuestionName.BORROWING_LIMIT);
+        BorrowingLimitEntireStatistic statistic = (BorrowingLimitEntireStatistic) populationStatistic.getStatistic();
+        long entireAverage = statistic.getBorrowingMoneyLimitEntireAverage();
+
+        return new MoneyDashboardComponent(statistics, entireAverage);
     }
 
     private void validateFilterCategory(Period period, Relation relation) {

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
@@ -21,7 +21,7 @@ public class MoneyDashboardComponent extends DashboardComponent {
     public void calculate(Statistics statistics) {
         AverageStatistic money = (AverageStatistic) statistics.getStatisticsByDashboardType(this.dashboardType).get(0);
         this.peopleCount = money.getTotalCount();
-        this.average = money.getTotalSum();
+        this.average = money.getAverage();
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
@@ -8,19 +8,20 @@ import lombok.Getter;
 @Getter
 public class MoneyDashboardComponent extends DashboardComponent {
     private long peopleCount;
-    private long moneySum;
     private long average;
+    private long entireAverage;
 
-    public MoneyDashboardComponent(Statistics statistics) {
+    public MoneyDashboardComponent(Statistics statistics, long entireAverage) {
         super(DashboardType.MONEY);
         calculate(statistics);
+        this.entireAverage = entireAverage;
     }
 
     @Override
     public void calculate(Statistics statistics) {
         AverageStatistic money = (AverageStatistic) statistics.getStatisticsByDashboardType(this.dashboardType).get(0);
         this.peopleCount = money.getTotalCount();
-        this.moneySum = money.getTotalSum();
+        this.average = money.getTotalSum();
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
@@ -1,12 +1,6 @@
 package com.dnd.namuiwiki.domain.dashboard.model.entity;
 
 import com.dnd.namuiwiki.common.model.BaseTimeEntity;
-import com.dnd.namuiwiki.domain.dashboard.model.BestWorthDashboardComponent;
-import com.dnd.namuiwiki.domain.dashboard.model.CharacterDashboardComponent;
-import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponent;
-import com.dnd.namuiwiki.domain.dashboard.model.HappyDashboardComponent;
-import com.dnd.namuiwiki.domain.dashboard.model.MoneyDashboardComponent;
-import com.dnd.namuiwiki.domain.dashboard.model.SadDashboardComponent;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import com.dnd.namuiwiki.domain.survey.type.Period;
@@ -39,16 +33,6 @@ public class Dashboard extends BaseTimeEntity {
 
     public void updateStatistics(List<Survey.Answer> answer) {
         statistics.updateStatistics(answer);
-    }
-
-    public List<DashboardComponent> getDashboardComponents() {
-        return List.of(
-                new BestWorthDashboardComponent(statistics),
-                new HappyDashboardComponent(statistics),
-                new SadDashboardComponent(statistics),
-                new CharacterDashboardComponent(statistics),
-                new MoneyDashboardComponent(statistics)
-        );
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsRepository.java
@@ -1,0 +1,13 @@
+package com.dnd.namuiwiki.domain.statistic;
+
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.statistic.model.entity.PopulationStatistic;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface StatisticsRepository extends MongoRepository<PopulationStatistic, String> {
+    Optional<PopulationStatistic> findByPeriodAndRelationAndQuestionName(Period period, Relation relation, QuestionName name);
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -26,12 +26,12 @@ public class StatisticsService {
                 .filter(answer -> answer.getQuestion().getDashboardType().getStatisticsType().isNotNone())
                 .toList();
 
-        updateStatisticsByCategory(owner, null, null, statisticalAnswers);
-        updateStatisticsByCategory(owner, period, null, statisticalAnswers);
-        updateStatisticsByCategory(owner, null, relation, statisticalAnswers);
+        updateDashboardByCategory(owner, null, null, statisticalAnswers);
+        updateDashboardByCategory(owner, period, null, statisticalAnswers);
+        updateDashboardByCategory(owner, null, relation, statisticalAnswers);
     }
 
-    private void updateStatisticsByCategory(User owner, Period period, Relation relation, List<Survey.Answer> answers) {
+    private void updateDashboardByCategory(User owner, Period period, Relation relation, List<Survey.Answer> answers) {
         Dashboard dashboard = dashboardRepository.findByUserAndPeriodAndRelation(owner, period, relation)
                 .orElseGet(() -> {
                     Dashboard newDashboard = Dashboard.builder()

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -44,7 +44,9 @@ public class StatisticsService {
                 .orElseGet(() -> PopulationStatistic.builder()
                         .statistic(new BorrowingLimitEntireStatistic(0L, 0L))
                         .period(period)
-                        .relation(relation).build());
+                        .questionName(questionName)
+                        .relation(relation)
+                        .build());
     }
 
     private void updateDashboards(User owner, Period period, Relation relation, List<Survey.Answer> statisticalAnswers) {

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -1,8 +1,14 @@
 package com.dnd.namuiwiki.domain.statistic;
 
+import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
+import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
-import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.option.entity.Option;
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.statistic.model.BorrowingLimitEntireStatistic;
+import com.dnd.namuiwiki.domain.statistic.model.Statistics;
+import com.dnd.namuiwiki.domain.statistic.model.entity.PopulationStatistic;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
@@ -16,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StatisticsService {
     private final DashboardRepository dashboardRepository;
+    private final StatisticsRepository statisticsRepository;
 
     public void updateStatistics(Survey survey) {
         User owner = survey.getOwner();
@@ -26,6 +33,21 @@ public class StatisticsService {
                 .filter(answer -> answer.getQuestion().getDashboardType().getStatisticsType().isNotNone())
                 .toList();
 
+        updateDashboards(owner, period, relation, statisticalAnswers);
+        updateBorrowingLimitStatistic(period, relation, statisticalAnswers);
+
+    }
+
+    public PopulationStatistic getPopulationStatistic(Period period, Relation relation, QuestionName questionName) {
+        return statisticsRepository
+                .findByPeriodAndRelationAndQuestionName(period, relation, questionName)
+                .orElseGet(() -> PopulationStatistic.builder()
+                        .statistic(new BorrowingLimitEntireStatistic(0L, 0L))
+                        .period(period)
+                        .relation(relation).build());
+    }
+
+    private void updateDashboards(User owner, Period period, Relation relation, List<Survey.Answer> statisticalAnswers) {
         updateDashboardByCategory(owner, null, null, statisticalAnswers);
         updateDashboardByCategory(owner, period, null, statisticalAnswers);
         updateDashboardByCategory(owner, null, relation, statisticalAnswers);
@@ -44,6 +66,36 @@ public class StatisticsService {
                 });
         dashboard.updateStatistics(answers);
         dashboardRepository.save(dashboard);
+    }
+
+    private void updateBorrowingLimitStatistic(Period period, Relation relation, List<Survey.Answer> answers) {
+        Survey.Answer borroingLimitAnswer = answers.stream()
+                .filter(answer -> answer.getQuestion().getName() == QuestionName.BORROWING_LIMIT)
+                .findFirst()
+                .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_DATA_ARGUMENT));
+
+        long borrowingLimit;
+        if (borroingLimitAnswer.getType().isOption()) {
+            Option option = borroingLimitAnswer.getQuestion().getOptions().get(borroingLimitAnswer.getAnswer().toString());
+            borrowingLimit = (long) option.getValue();
+        } else {
+            borrowingLimit = (long) borroingLimitAnswer.getAnswer();
+        }
+
+        updateBorrowingLimitStatisticByCategory(null, null, borrowingLimit);
+        updateBorrowingLimitStatisticByCategory(period, null, borrowingLimit);
+        updateBorrowingLimitStatisticByCategory(null, relation, borrowingLimit);
+    }
+
+    private void updateBorrowingLimitStatisticByCategory(Period period, Relation relation, long borrowingLimit) {
+        PopulationStatistic populationStatistic = getPopulationStatistic(period, relation, QuestionName.BORROWING_LIMIT);
+
+        BorrowingLimitEntireStatistic statistic = (BorrowingLimitEntireStatistic) populationStatistic.getStatistic();
+        statistic.updateStatistic(String.valueOf(borrowingLimit));
+
+        populationStatistic.setStatistic(statistic);
+
+        statisticsRepository.save(populationStatistic);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/AverageStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/AverageStatistic.java
@@ -2,6 +2,7 @@ package com.dnd.namuiwiki.domain.statistic.model;
 
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
+import com.dnd.namuiwiki.common.util.ArithmeticUtils;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
 import com.dnd.namuiwiki.domain.option.entity.Option;
 import com.dnd.namuiwiki.domain.question.entity.Question;
@@ -11,30 +12,17 @@ import lombok.Getter;
 
 @Getter
 public class AverageStatistic extends Statistic {
-    private Long totalSum;
+    private long average;
 
     public AverageStatistic(
             String questionId,
             QuestionName questionName,
             DashboardType dashboardType,
             Long totalCount,
-            Long totalSum
+            Long average
     ) {
         super(questionId, questionName, dashboardType, totalCount);
-        this.totalSum = totalSum;
-    }
-
-    public Long increaseTotalSum(Long sum) {
-        return totalSum += sum;
-    }
-
-    public static AverageStatistic create(Question question) {
-        return new AverageStatistic(
-                question.getId(),
-                question.getName(),
-                question.getDashboardType(),
-                0L,
-                0L);
+        this.average = average;
     }
 
     @Override
@@ -52,8 +40,21 @@ public class AverageStatistic extends Statistic {
                 throw new ApplicationErrorException(ApplicationErrorType.INTERNAL_ERROR, "Invalid statistics type");
         }
 
+        updateAverage(value);
         increaseTotalCount();
-        increaseTotalSum(value);
+    }
+
+    public void updateAverage(Long newNumber) {
+        average = ArithmeticUtils.calculateAverage(totalCount, average, newNumber);
+    }
+
+    public static AverageStatistic create(Question question) {
+        return new AverageStatistic(
+                question.getId(),
+                question.getName(),
+                question.getDashboardType(),
+                0L,
+                0L);
     }
 
     private long getValueFromManualAnswer(Survey.Answer answer) {

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
@@ -1,5 +1,6 @@
 package com.dnd.namuiwiki.domain.statistic.model;
 
+import com.dnd.namuiwiki.common.util.ArithmeticUtils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,7 +15,7 @@ public class BorrowingLimitEntireStatistic implements EntireStatistic {
     @Override
     public void updateStatistic(String... args) {
         long borrowingLimit = Long.parseLong(args[0]);
-        long newAverage = (peopleCount + borrowingLimit) / 2;
+        long newAverage = ArithmeticUtils.calculateAverage(peopleCount, borrowingMoneyLimitEntireAverage, borrowingLimit);
 
         increasePeopleCount();
         setBorrowingMoneyLimitEntireAverage(newAverage);

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
@@ -1,0 +1,31 @@
+package com.dnd.namuiwiki.domain.statistic.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BorrowingLimitEntireStatistic implements EntireStatistic {
+
+    private long borrowingMoneyLimitEntireAverage;
+    private long peopleCount;
+
+
+    @Override
+    public void updateStatistic(String... args) {
+        long borrowingLimit = Long.parseLong(args[0]);
+        long newAverage = (peopleCount * borrowingMoneyLimitEntireAverage + borrowingLimit) / (peopleCount + 1);
+
+        increasePeopleCount();
+        setBorrowingMoneyLimitEntireAverage(newAverage);
+    }
+
+    private void increasePeopleCount() {
+        peopleCount++;
+    }
+
+    private void setBorrowingMoneyLimitEntireAverage(long borrowingMoneyLimitEntireAverage) {
+        this.borrowingMoneyLimitEntireAverage = borrowingMoneyLimitEntireAverage;
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/BorrowingLimitEntireStatistic.java
@@ -14,7 +14,7 @@ public class BorrowingLimitEntireStatistic implements EntireStatistic {
     @Override
     public void updateStatistic(String... args) {
         long borrowingLimit = Long.parseLong(args[0]);
-        long newAverage = (peopleCount * borrowingMoneyLimitEntireAverage + borrowingLimit) / (peopleCount + 1);
+        long newAverage = (peopleCount + borrowingLimit) / 2;
 
         increasePeopleCount();
         setBorrowingMoneyLimitEntireAverage(newAverage);

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/EntireStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/EntireStatistic.java
@@ -1,0 +1,5 @@
+package com.dnd.namuiwiki.domain.statistic.model;
+
+public interface EntireStatistic {
+    void updateStatistic(String... arguments);
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistic.java
@@ -2,8 +2,8 @@ package com.dnd.namuiwiki.domain.statistic.model;
 
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
-import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.statistic.type.StatisticsType;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
@@ -13,10 +13,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public abstract class Statistic {
-    private String questionId;
-    private QuestionName questionName;
-    private DashboardType dashboardType;
-    private Long totalCount;
+    protected String questionId;
+    protected QuestionName questionName;
+    protected DashboardType dashboardType;
+    protected Long totalCount;
 
     public Long increaseTotalCount() {
         return ++totalCount;

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/entity/PopulationStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/entity/PopulationStatistic.java
@@ -1,0 +1,30 @@
+package com.dnd.namuiwiki.domain.statistic.model.entity;
+
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.statistic.model.EntireStatistic;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@Builder
+@Document("statistics")
+public class PopulationStatistic {
+
+    @Id
+    private String id;
+
+    private Period period;
+
+    private Relation relation;
+
+    private QuestionName questionName;
+
+    private EntireStatistic statistic;
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -29,7 +29,7 @@ public class SurveyService {
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
         User sender = getUserByAccessToken(accessToken);
 
-//        validateNotFromMe(owner, sender);
+        validateNotFromMe(owner, sender);
 
         Survey survey = surveyRepository.save(Survey.builder()
                 .owner(owner)


### PR DESCRIPTION
it closes #38 

## 요약
전체 통계량 필요한 대시보드 계산 로직 추가되었습니다.

## 변경된 점
- statistics Collection 생성하였습니다. Entity 클래스 이름은 `PopulationStatistic`입니다.
  - `statistic` 필드를 가지고, `EntireStatistic` 클래스 타입입니다.
- BORROWING_LIMIT 질문에 해당하는 통계량 클래스 정의하였습니다.

## 특이 사항

