### PR TITLE
유저 퍼블릭 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/user/UserController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,6 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+
+    @GetMapping()
+    public ResponseEntity<?> getUserPublicProfile(
+            @RequestParam String wikiId
+    ) {
+        var response = userService.getUserPublicProfile(wikiId);
+        return ResponseDto.ok(response);
+    }
 
     @GetMapping("/profile")
     public ResponseEntity<?> getMyProfile(

--- a/src/main/java/com/dnd/namuiwiki/domain/user/UserService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/UserService.java
@@ -12,6 +12,7 @@ import com.dnd.namuiwiki.domain.oauth.dto.OAuthUserInfoDto;
 import com.dnd.namuiwiki.domain.oauth.type.OAuthProvider;
 import com.dnd.namuiwiki.domain.survey.SurveyRepository;
 import com.dnd.namuiwiki.domain.user.dto.EditUserProfileRequest;
+import com.dnd.namuiwiki.domain.user.dto.GetUserPublicProfileResponse;
 import com.dnd.namuiwiki.domain.user.dto.UserProfileDto;
 import com.dnd.namuiwiki.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +67,12 @@ public class UserService {
         user.setRefreshToken(tokenPair.getRefreshToken());
         userRepository.save(user);
         return SignUpResponse.from(tokenPair);
+    }
+
+    public GetUserPublicProfileResponse getUserPublicProfile(String wikiId) {
+        User user = userRepository.findByWikiId(wikiId)
+                .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
+        return new GetUserPublicProfileResponse(user.getNickname());
     }
 
     private MultiValueMap<String, String> getOauthCookie(OAuthUserInfoDto oAuthUserInfoDto) {

--- a/src/main/java/com/dnd/namuiwiki/domain/user/dto/GetUserPublicProfileResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/user/dto/GetUserPublicProfileResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.namuiwiki.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GetUserPublicProfileResponse {
+    private String nickname;
+}


### PR DESCRIPTION
이 PR은 #46 이 머지된 후 머지됩니다.

## 요약
유저 퍼블릭 정보 조회 api 구현

## 변경된 점
- `GET` /api/v1/users?wikiId={wikiId}

## 특이 사항
- application property 업데이트되었습니다.
