### PR TITLE
feat: 문항 조회 시 타입 필터 추가(#66)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionController.java
@@ -1,6 +1,7 @@
 package com.dnd.namuiwiki.domain.question;
 
 import com.dnd.namuiwiki.common.dto.ResponseDto;
+import com.dnd.namuiwiki.domain.question.type.QuestionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +25,10 @@ public class QuestionController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getQuestions() {
-        var response = questionService.getQuestions();
+    public ResponseEntity<?> getQuestions(
+            @RequestParam(required = false, name = "type") QuestionType questionType
+    ) {
+        var response = questionService.getQuestions(questionType);
         return ResponseDto.ok(response);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
@@ -34,8 +34,9 @@ public class QuestionService {
     @Value("${setting.password}")
     private String SETTING_PASSWORD;
 
-    public List<QuestionDto> getQuestions() {
+    public List<QuestionDto> getQuestions(QuestionType questionType) {
         return questionRepository.findAll().stream()
+                .filter(q -> questionType == null || q.getType().equals(questionType))
                 .sorted(Comparator.comparing(Question::getSurveyOrder))
                 .map(QuestionDto::from)
                 .toList();


### PR DESCRIPTION
## 요약
문항 조회 시 타입 필터 추가하였습니다.

## 변경된 점
- QuestionType을 받아 null일 시 전체, 타입이 존재할 시 해당 타입의 문항을 응답합니다.

