### PR TITLE
feat: permitted url을 method도 함께 검증(#47)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
+++ b/src/main/java/com/dnd/namuiwiki/common/filter/JwtFilter.java
@@ -4,7 +4,8 @@ import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.jwt.JwtProvider;
 import io.jsonwebtoken.Claims;
-import jakarta.servlet.*;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,18 +13,19 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
 
-    private final List<String> excludeUrlPatterns;
+    private final Map<String, String> excludeUrlPatterns;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     private final String AUTHENTICATION_HEADER;
     private final String HTTP_METHOD_OPTIONS = "OPTIONS";
+    private final String WILDCARD = "*";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -39,8 +41,16 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return excludeUrlPatterns.stream()
-                .anyMatch(p -> antPathMatcher.match(p, request.getServletPath()));
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return excludeUrlPatterns.entrySet().stream()
+                .anyMatch((entry) -> {
+                    String path = entry.getKey();
+                    String method = entry.getValue();
+
+                    boolean methodMatched = method.equals(WILDCARD) || method.equals(request.getMethod());
+                    boolean uriMatched = antPathMatcher.match(path, request.getServletPath());
+                    return methodMatched && uriMatched;
+                });
     }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/FilterConfiguration.java
@@ -10,7 +10,9 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
@@ -28,7 +30,17 @@ public class FilterConfiguration {
     @Bean
     public FilterRegistrationBean<JwtFilter> jwtFilter() {
         FilterRegistrationBean<JwtFilter> jwtFilterBean = new FilterRegistrationBean<>();
-        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, List.of(permittedURIs), AUTHENTICATION_HEADER));
+        Map<String, String> excludeUrlPatterns = new HashMap<>();
+
+        for (int i = 0; i < permittedURIs.length; i++) {
+            String[] split = permittedURIs[i].split(":");
+            String method = split[0];
+            String path = split[1];
+
+            excludeUrlPatterns.put(path, method);
+        }
+
+        jwtFilterBean.setFilter(new JwtFilter(jwtProvider, excludeUrlPatterns, AUTHENTICATION_HEADER));
         jwtFilterBean.setOrder(2);
         return jwtFilterBean;
     }


### PR DESCRIPTION
## 요약
permitted url을 method도 함께 검증합니다.

## 변경된 점
- application-local에 등록되는 permit-uri 의 형식을 `method:uri`로 설정합니다.
- 필터 제외 조건
  - method가 WILDCARD(`*`)일 경우
  - request uri와 method가 각각 permit-uri 값들 중 하나와 패턴이 일치하고, method가 일치할 경우



