### PR TITLE
대시보드 Character 타입에 questionId 포함

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -52,7 +52,7 @@ public class DashboardService {
                 new BestWorthDashboardComponent(statistics, getQuestionIdByQuestionNAme(questions, QuestionName.CORE_VALUE)),
                 new HappyDashboardComponent(statistics, getQuestionIdByQuestionNAme(questions, QuestionName.HAPPY_BEHAVIOR)),
                 new SadDashboardComponent(statistics, getQuestionIdByQuestionNAme(questions, QuestionName.SAD_ANGRY_BEHAVIOR)),
-                new CharacterDashboardComponent(statistics, getQuestionIdByQuestionNAme(questions, QuestionName.CHARACTER_CELEBRITY_ASSOCIATION)),
+                new CharacterDashboardComponent(statistics),
                 getMoneyDashboardComponent(statistics, period, relation, getQuestionIdByQuestionNAme(questions, QuestionName.BORROWING_LIMIT))
         );
         return new DashboardDto(dashboardComponents);

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
@@ -10,10 +10,13 @@ import java.util.List;
 
 @Getter
 public class BestWorthDashboardComponent extends DashboardComponent {
+    private final String questionId;
     private List<RatioDto> rank;
 
     public BestWorthDashboardComponent(Statistics statistics, String questionId) {
-        super(DashboardType.BEST_WORTH, questionId);
+        super(DashboardType.BEST_WORTH);
+        this.questionId = questionId;
+
         calculate(statistics);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/CharacterDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/CharacterDashboardComponent.java
@@ -20,8 +20,8 @@ public class CharacterDashboardComponent extends DashboardComponent {
     private boolean mbti;
     private boolean busy;
 
-    public CharacterDashboardComponent(Statistics statistics, String questionId) {
-        super(DashboardType.CHARACTER, questionId);
+    public CharacterDashboardComponent(Statistics statistics) {
+        super(DashboardType.CHARACTER);
         calculate(statistics);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/DashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/DashboardComponent.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 public abstract class DashboardComponent {
 
     protected final DashboardType dashboardType;
-    protected final String questionId;
 
     public abstract void calculate(Statistics statistics);
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
@@ -11,9 +11,12 @@ import java.util.List;
 @Getter
 public class HappyDashboardComponent extends DashboardComponent {
     private List<RatioDto> rank;
+    private final String questionId;
 
     public HappyDashboardComponent(Statistics statistics, String questionId) {
-        super(DashboardType.HAPPY, questionId);
+        super(DashboardType.HAPPY);
+        this.questionId = questionId;
+
         calculate(statistics);
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/MoneyDashboardComponent.java
@@ -7,14 +7,17 @@ import lombok.Getter;
 
 @Getter
 public class MoneyDashboardComponent extends DashboardComponent {
+    private final String questionId;
     private long peopleCount;
     private long average;
     private long entireAverage;
 
     public MoneyDashboardComponent(Statistics statistics, long entireAverage, String questionId) {
-        super(DashboardType.MONEY, questionId);
-        calculate(statistics);
+        super(DashboardType.MONEY);
         this.entireAverage = entireAverage;
+        this.questionId = questionId;
+
+        calculate(statistics);
     }
 
     @Override

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
@@ -10,10 +10,13 @@ import java.util.List;
 
 @Getter
 public class SadDashboardComponent extends DashboardComponent {
+    private final String questionId;
     private List<RatioDto> rank;
 
     public SadDashboardComponent(Statistics statistics, String questionId) {
-        super(DashboardType.SAD, questionId);
+        super(DashboardType.SAD);
+        this.questionId = questionId;
+
         calculate(statistics);
     }
 


### PR DESCRIPTION
it closes #100 

## 요약
대시보드 Character 타입에 questionId 포함하도록 수정하였습니다.

## 변경된 점
- 기존에 있던 friendly, similar, mbti, busy 필드 삭제
- 위 필드를 Character 리스트 필드로 관리하도록 수정
- Character 클래스 - name, value, questionId 필드 

## 특이 사항

