### PR TITLE
Question을 Bean으로 등록하여 캐싱

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
@@ -1,0 +1,16 @@
+package com.dnd.namuiwiki.config;
+
+import com.dnd.namuiwiki.domain.question.QuestionCacheManager;
+import com.dnd.namuiwiki.domain.question.QuestionRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfiguration {
+
+    @Bean
+    public QuestionCacheManager questionCache(QuestionRepository questionRepository) {
+        return new QuestionCacheManager(questionRepository);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
@@ -1,16 +1,28 @@
 package com.dnd.namuiwiki.config;
 
-import com.dnd.namuiwiki.domain.question.QuestionCache;
-import com.dnd.namuiwiki.domain.question.QuestionRepository;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@EnableCaching
 @Configuration
 public class CacheConfiguration {
 
     @Bean
-    public QuestionCache questionCache(QuestionRepository questionRepository) {
-        return new QuestionCache(questionRepository);
+    CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        List<Cache> caches = new ArrayList<>();
+        caches.add(new ConcurrentMapCache("questions"));
+        caches.add(new ConcurrentMapCache("question"));
+        cacheManager.setCaches(caches);
+        return cacheManager;
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/CacheConfiguration.java
@@ -1,6 +1,6 @@
 package com.dnd.namuiwiki.config;
 
-import com.dnd.namuiwiki.domain.question.QuestionCacheManager;
+import com.dnd.namuiwiki.domain.question.QuestionCache;
 import com.dnd.namuiwiki.domain.question.QuestionRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,8 +9,8 @@ import org.springframework.context.annotation.Configuration;
 public class CacheConfiguration {
 
     @Bean
-    public QuestionCacheManager questionCache(QuestionRepository questionRepository) {
-        return new QuestionCacheManager(questionRepository);
+    public QuestionCache questionCache(QuestionRepository questionRepository) {
+        return new QuestionCache(questionRepository);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionCache.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionCache.java
@@ -7,13 +7,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class QuestionCacheManager {
+public class QuestionCache {
 
     private final QuestionRepository questionRepository;
 
     private Map<String, Question> cachedQuestions;
 
-    public QuestionCacheManager(QuestionRepository questionRepository) {
+    public QuestionCache(QuestionRepository questionRepository) {
         this.questionRepository = questionRepository;
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionCacheManager.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionCacheManager.java
@@ -1,0 +1,36 @@
+package com.dnd.namuiwiki.domain.question;
+
+import com.dnd.namuiwiki.domain.question.entity.Question;
+import jakarta.annotation.PostConstruct;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class QuestionCacheManager {
+
+    private final QuestionRepository questionRepository;
+
+    private Map<String, Question> cachedQuestions;
+
+    public QuestionCacheManager(QuestionRepository questionRepository) {
+        this.questionRepository = questionRepository;
+    }
+
+    @PostConstruct
+    public void initializeCache() {
+        Map<String, Question> objectObjectHashMap = new HashMap<>();
+        questionRepository.findAll()
+                .forEach(question -> objectObjectHashMap.put(question.getId(), question));
+        this.cachedQuestions = objectObjectHashMap;
+    }
+
+    public Map<String, Question> findAll() {
+        return cachedQuestions;
+    }
+
+    public Optional<Question> findById(String id) {
+        return Optional.ofNullable(cachedQuestions.get(id));
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionRepository.java
@@ -1,7 +1,21 @@
 package com.dnd.namuiwiki.domain.question;
 
 import com.dnd.namuiwiki.domain.question.entity.Question;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends MongoRepository<Question, String> {
+
+    @NonNull
+    @Cacheable("questions")
+    List<Question> findAll();
+
+    @NonNull
+    @Cacheable("question")
+    Optional<Question> findById(@NonNull String id);
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
@@ -31,13 +31,11 @@ public class QuestionService {
     private final OptionRepository optionRepository;
     private final QuestionRepository questionRepository;
 
-    private final QuestionCache questionCache;
-
     @Value("${setting.password}")
     private String SETTING_PASSWORD;
 
     public List<QuestionDto> getQuestions(QuestionType questionType) {
-        return questionCache.findAll().values().stream()
+        return questionRepository.findAll().stream()
                 .filter(q -> questionType == null || q.getType().equals(questionType))
                 .sorted(Comparator.comparing(Question::getSurveyOrder))
                 .map(QuestionDto::from)

--- a/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/QuestionService.java
@@ -31,11 +31,13 @@ public class QuestionService {
     private final OptionRepository optionRepository;
     private final QuestionRepository questionRepository;
 
+    private final QuestionCache questionCache;
+
     @Value("${setting.password}")
     private String SETTING_PASSWORD;
 
     public List<QuestionDto> getQuestions(QuestionType questionType) {
-        return questionRepository.findAll().stream()
+        return questionCache.findAll().values().stream()
                 .filter(q -> questionType == null || q.getType().equals(questionType))
                 .sorted(Comparator.comparing(Question::getSurveyOrder))
                 .map(QuestionDto::from)

--- a/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
@@ -28,7 +28,7 @@ public class Question extends BaseTimeEntity {
     private Long surveyOrder;
     private boolean reasonRequired;
 
-    @DocumentReference
+    @DocumentReference(collection = "options", lazy = true)
     private Map<String, Option> options;
 
     public Optional<Option> getOption(String optionId) {

--- a/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
@@ -28,7 +28,7 @@ public class Question extends BaseTimeEntity {
     private Long surveyOrder;
     private boolean reasonRequired;
 
-    @DocumentReference(collection = "options", lazy = true)
+    @DocumentReference(collection = "options")
     private Map<String, Option> options;
 
     public Optional<Option> getOption(String optionId) {

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/AnswerController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/AnswerController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,4 +41,12 @@ public class AnswerController {
         var answersByQuestion = surveyService.getAnswersByQuestion(tokenUserInfoDto.getWikiId(), questionId, period, relation, pageNo, pageSize);
         return ResponseDto.ok(answersByQuestion);
     }
+
+    @Operation(hidden = true)
+    @PutMapping("/set-question-id")
+    public ResponseEntity<?> setQuestionIdForSurveyAnswers(@RequestParam String pwd) {
+        surveyService.setQuestionIdForSurveyAnswers(pwd);
+        return ResponseDto.noContent();
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -132,7 +132,7 @@ public class SurveyService {
         Page<Survey> surveys = getReceivedSurveysByFilter(period, relation, owner, pageable);
         var answers = surveys.map(survey -> {
             var answerOfQuestion = survey.getAnswers().stream()
-                    .filter(answer -> answer.getQuestion().getId().equals(questionId))
+                    .filter(answer -> answer.getQuestionId().equals(questionId))
                     .findAny()
                     .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_QUESTION_ID));
             return SingleAnswerWithSurveyDetailDto.builder()
@@ -175,7 +175,7 @@ public class SurveyService {
     }
 
     private String convertAnswerToText(Question question, Answer answer) {
-        if (answer.getType().equals(AnswerType.MANUAL)) {
+        if (answer.getType().isManual()) {
             return answer.getAnswer().toString();
         }
         Option option = question.getOption(answer.getAnswer().toString())

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -7,7 +7,7 @@ import com.dnd.namuiwiki.domain.dashboard.DashboardService;
 import com.dnd.namuiwiki.domain.jwt.JwtProvider;
 import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import com.dnd.namuiwiki.domain.option.entity.Option;
-import com.dnd.namuiwiki.domain.question.QuestionCache;
+import com.dnd.namuiwiki.domain.question.QuestionRepository;
 import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.model.dto.AnswerDto;
@@ -40,7 +40,7 @@ import java.util.List;
 public class SurveyService {
     private final UserRepository userRepository;
     private final SurveyRepository surveyRepository;
-    private final QuestionCache questionCache;
+    private final QuestionRepository questionRepository;
     private final JwtProvider jwtProvider;
     private final StatisticsService statisticsService;
     private final DashboardService dashboardService;
@@ -116,7 +116,7 @@ public class SurveyService {
     }
 
     public GetSurveyResponse getSurvey(String surveyId) {
-        List<Question> questions = questionCache.findAll().values().stream().toList();
+        List<Question> questions = questionRepository.findAll().stream().toList();
         Survey survey = surveyRepository.findById(surveyId)
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_SURVEY));
         return GetSurveyResponse.from(survey, questions);
@@ -125,7 +125,7 @@ public class SurveyService {
     public GetAnswersByQuestionResponse getAnswersByQuestion(String wikiId, String questionId, Period period, Relation relation, int pageNo, int pageSize) {
         validateFilter(period, relation);
 
-        Question question = questionCache.findById(questionId)
+        Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_QUESTION_ID));
 
         User owner = userRepository.findByWikiId(wikiId)
@@ -188,7 +188,7 @@ public class SurveyService {
     }
 
     private Question getQuestionById(String questionId) {
-        return questionCache.findById(questionId)
+        return questionRepository.findById(questionId)
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_QUESTION_ID));
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -26,6 +26,7 @@ import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.UserRepository;
 import com.dnd.namuiwiki.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -43,6 +44,9 @@ public class SurveyService {
     private final JwtProvider jwtProvider;
     private final StatisticsService statisticsService;
     private final DashboardService dashboardService;
+
+    @Value("${setting.password}")
+    private String SETTING_PASSWORD;
 
     public CreateSurveyResponse createSurvey(CreateSurveyRequest request, String accessToken) {
         User owner = getUserByWikiId(request.getOwner());
@@ -202,4 +206,17 @@ public class SurveyService {
         return userRepository.findByWikiId(tokenUserInfoDto.getWikiId())
                 .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.NOT_FOUND_USER));
     }
+
+    public void setQuestionIdForSurveyAnswers(String pwd) {
+        if (!SETTING_PASSWORD.equals(pwd)) {
+            throw new ApplicationErrorException(ApplicationErrorType.NO_PERMISSION);
+        }
+
+        List<Survey> surveys = surveyRepository.findAll();
+        surveys.forEach(survey -> {
+            survey.setQuestionIdForAnswers();
+            surveyRepository.save(survey);
+        });
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/GetSurveyResponse.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/GetSurveyResponse.java
@@ -56,7 +56,7 @@ public class GetSurveyResponse {
 
         var answers = survey.getAnswers();
         List<SingleQuestionAndAnswer> questionAndAnswerList = new ArrayList<>();
-        answers.forEach(answer -> questionAndAnswerList.add(SingleQuestionAndAnswer.from(questionMap.get(answer.getQuestion().getId()), answer)));
+        answers.forEach(answer -> questionAndAnswerList.add(SingleQuestionAndAnswer.from(questionMap.get(answer.getQuestionId()), answer)));
         return questionAndAnswerList;
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
@@ -96,4 +96,8 @@ public class Answer {
         }
     }
 
+    protected void setQuestionId(String id) {
+        this.questionId = id;
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
@@ -18,6 +18,7 @@ public class Answer {
 
     @DocumentReference(collection = "questions", lazy = true)
     private Question question;
+    private String questionId;
     private AnswerType type;
     private Object answer;
     private String reason;
@@ -39,6 +40,7 @@ public class Answer {
         }
 
         this.question = question;
+        this.questionId = question.getId();
         this.type = type;
         this.reason = reason;
     }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
@@ -60,4 +60,9 @@ public class Survey extends BaseTimeEntity {
     public LocalDateTime getWrittenAt() {
         return this.createdAt;
     }
+
+    public void setQuestionIdForAnswers() {
+        answers.forEach(answer -> answer.setQuestionId(answer.getQuestion().getId()));
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
@@ -22,10 +22,10 @@ public class Survey extends BaseTimeEntity {
     @Id
     private String id;
 
-    @DocumentReference
+    @DocumentReference(collection = "users", lazy = true)
     private User owner;
 
-    @DocumentReference
+    @DocumentReference(collection = "users", lazy = true)
     private User sender;
 
     private String senderName;

--- a/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
+++ b/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
@@ -5,7 +5,7 @@ import com.dnd.namuiwiki.domain.dashboard.DashboardService;
 import com.dnd.namuiwiki.domain.jwt.JwtProvider;
 import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import com.dnd.namuiwiki.domain.option.entity.Option;
-import com.dnd.namuiwiki.domain.question.QuestionCache;
+import com.dnd.namuiwiki.domain.question.QuestionRepository;
 import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.question.type.QuestionType;
@@ -40,7 +40,7 @@ class SurveyServiceTest {
     @Mock
     private SurveyRepository surveyRepository;
     @Mock
-    private QuestionCache questionCache;
+    private QuestionRepository questionRepository;
     @Mock
     private JwtProvider jwtProvider;
     @Mock
@@ -52,7 +52,7 @@ class SurveyServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        surveyService = new SurveyService(userRepository, surveyRepository, questionCache, jwtProvider, statisticsService, dashboardService);
+        surveyService = new SurveyService(userRepository, surveyRepository, questionRepository, jwtProvider, statisticsService, dashboardService);
     }
 
     @Test
@@ -93,7 +93,7 @@ class SurveyServiceTest {
             Option option = Option.builder().id("optionId").build();
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of(option.getId(), option)).build();
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // when
             Answer surveyAnswer = surveyService.convertAnswer(answerOfOptionType);
@@ -109,7 +109,7 @@ class SurveyServiceTest {
             QuestionType questionType = QuestionType.OX;
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of()).build();
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // then
             assertThatThrownBy(() -> surveyService.convertAnswer(answerOfOptionType))
@@ -121,7 +121,7 @@ class SurveyServiceTest {
         @DisplayName("questionId에 해당하는 Question이 없을 경우 에러 발생")
         void throwExceptionIfQuestionDocuementNotExists() {
             // given
-            given(questionCache.findById(any(String.class))).willReturn(Optional.empty());
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.empty());
 
             // then
             assertThatThrownBy(() -> surveyService.convertAnswer(answerOfOptionType))
@@ -134,12 +134,10 @@ class SurveyServiceTest {
         void throwExceptionIfQuestionDoesntHaveOption() {
             // given
             QuestionType questionType = QuestionType.OX;
-            Option option = Option.builder().id("notOptionId").build();
             Option realOption = Option.builder().id("realOptionId").build();
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of(realOption.getId(), realOption)).build();
-            var answers = List.of(answerOfOptionType);
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // then
             assertThatThrownBy(() -> surveyService.convertAnswer(answerOfOptionType))
@@ -164,9 +162,8 @@ class SurveyServiceTest {
             // given
             QuestionType questionType = QuestionType.SHORT_ANSWER;
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of()).build();
-            var answers = List.of(answerOfManualType);
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // when
             Answer answer = surveyService.convertAnswer(answerOfManualType);
@@ -182,9 +179,8 @@ class SurveyServiceTest {
             // given
             QuestionType questionType = QuestionType.SHORT_ANSWER;
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of()).build();
-            var answers = List.of(answerOfManualType);
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // when
             Answer answer = surveyService.convertAnswer(answerOfManualType);
@@ -208,7 +204,7 @@ class SurveyServiceTest {
             Question question = Question.builder().id("questionId").type(questionType).options(Map.of()).name(QuestionName.BORROWING_LIMIT).build();
             int intAnswer = 100000;
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // when
             Answer answer = surveyService.convertAnswer(AnswerDto.builder()
@@ -234,7 +230,7 @@ class SurveyServiceTest {
                     .answer(stringAnswer)
                     .build();
 
-            given(questionCache.findById(any(String.class))).willReturn(Optional.of(question));
+            given(questionRepository.findById(any(String.class))).willReturn(Optional.of(question));
 
             // then
             assertThatThrownBy(() -> surveyService.convertAnswer(answer))


### PR DESCRIPTION
## 요약
Spring의 SimpleCacheManager를 이용하여 Question을 캐싱하도록 설정하였습니다.

## 변경된 점
- ~QuestionCache 컴포넌트 생성~ --> SimpleCacheManager 등록
- Survey.Ansewr에 questionId 필드를 추가하였습니다.
- 문항 조회, 설문 조회, 설문 생성, 질문별 답변 api에 QuestionCache 사용하도록 수정

## 특이 사항
surveys 안에 있는 모든 Survey Document에 questionId 필드 추가해야 합니다.
해당 작업을 수행하는 API를 만들었는데, 더 좋은 방법이 있다면 알려주세요🙏
