### PR TITLE
fix: 직접 입력일 경우 option 카운팅하지 않도록 수정

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/RatioStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/RatioStatistic.java
@@ -50,6 +50,12 @@ public class RatioStatistic extends Statistic {
     public void updateStatistic(Answer answer) {
         increaseTotalCount();
 
+        if (answer.getType().isOption()) {
+            increaseOptionCount(answer);
+        }
+    }
+
+    private void increaseOptionCount(Answer answer) {
         Question question = answer.getQuestion();
         String optionId = answer.getAnswer().toString();
         Legend legend = getLegend(optionId)


### PR DESCRIPTION
## 요약
직접 입력일 경우 option이 없어서 발생하는 에러입니다.

## 변경된 점
옵션 선택일 경우에만 옵션 관련 통계량을 변경하도록 수정하였습니다.

## 특이 사항

