### PR TITLE
통계 업데이트를 이벤트 기반으로 변경

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/exception/AsyncExceptionHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/common/exception/AsyncExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.dnd.namuiwiki.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("AsyncException message={}, declaringClass={}, methodName={}", ex.getMessage(), method.getDeclaringClass(), method.getName(), ex);
+
+        for (Object param : params) {
+            log.error("Parameter value - {}, declaringClass={}, methodName={}", param, method.getDeclaringClass(), method.getName());
+        }
+
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
@@ -1,9 +1,24 @@
 package com.dnd.namuiwiki.config;
 
+import com.dnd.namuiwiki.common.exception.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @Configuration
-public class AsyncConfiguration {
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return asyncExceptionHandler();
+    }
+
+    @Bean
+    public AsyncExceptionHandler asyncExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
@@ -1,0 +1,9 @@
+package com.dnd.namuiwiki.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfiguration {
+}

--- a/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
@@ -1,0 +1,21 @@
+package com.dnd.namuiwiki.config;
+
+import com.dnd.namuiwiki.domain.dashboard.DashboardService;
+import com.dnd.namuiwiki.domain.statistic.StatisticsService;
+import com.dnd.namuiwiki.domain.survey.SurveyEventHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class EventConfiguration {
+    private final StatisticsService statisticsService;
+    private final DashboardService dashboardService;
+
+    @Bean
+    public SurveyEventHandler surveyEventHandler() {
+        return new SurveyEventHandler(statisticsService, dashboardService);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -15,12 +15,15 @@ import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.UserRepository;
 import com.dnd.namuiwiki.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DashboardService {
@@ -60,6 +63,7 @@ public class DashboardService {
     }
 
 
+    @Async
     public void updateStatistics(Survey survey) {
         User owner = survey.getOwner();
         Period period = survey.getPeriod();
@@ -70,6 +74,8 @@ public class DashboardService {
                 .toList();
 
         updateDashboards(owner, period, relation, statisticalAnswers);
+
+        log.info("DashboardService.updateStatistics done: owner={}, period={}, relation={}, answerSize={}", owner, period, relation, statisticalAnswers.size());
     }
 
     private void updateDashboards(User owner, Period period, Relation relation, List<Answer> statisticalAnswers) {

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -63,7 +63,6 @@ public class DashboardService {
     }
 
 
-    @Async
     public void updateStatistics(Survey survey) {
         User owner = survey.getOwner();
         Period period = survey.getPeriod();

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/RatioStatistic.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/RatioStatistic.java
@@ -50,6 +50,12 @@ public class RatioStatistic extends Statistic {
     public void updateStatistic(Answer answer) {
         increaseTotalCount();
 
+        if (answer.getType().isOption()) {
+            increaseOptionCount(answer);
+        }
+    }
+
+    private void increaseOptionCount(Answer answer) {
         Question question = answer.getQuestion();
         String optionId = answer.getAnswer().toString();
         Legend legend = getLegend(optionId)

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -19,7 +19,6 @@ import java.util.List;
 public class StatisticsService {
     private final StatisticsRepository statisticsRepository;
 
-    @Async
     public void updateStatistics(Survey survey) {
         Period period = survey.getPeriod();
         Relation relation = survey.getRelation();

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
@@ -1,0 +1,28 @@
+package com.dnd.namuiwiki.domain.survey;
+
+import com.dnd.namuiwiki.domain.dashboard.DashboardService;
+import com.dnd.namuiwiki.domain.statistic.StatisticsService;
+import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveySuccessEvent;
+import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SurveyEventHandler {
+    private final StatisticsService statisticsService;
+    private final DashboardService dashboardService;
+
+    @Async
+    @EventListener
+    public void handleSurveySuccessEvent(CreateSurveySuccessEvent event) {
+        Survey survey = event.getSurvey();
+        log.info("SurveyEventHandler.handleSurveySuccessEvent: surveyId={}", survey.getId());
+
+        dashboardService.updateStatistics(survey);
+        statisticsService.updateStatistics(survey);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/CreateSurveySuccessEvent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/CreateSurveySuccessEvent.java
@@ -1,0 +1,11 @@
+package com.dnd.namuiwiki.domain.survey.model.dto;
+
+import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateSurveySuccessEvent {
+    private final Survey survey;
+}

--- a/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
+++ b/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
@@ -1,7 +1,6 @@
 package com.dnd.namuiwiki.domain.survey;
 
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
-import com.dnd.namuiwiki.domain.dashboard.DashboardService;
 import com.dnd.namuiwiki.domain.jwt.JwtProvider;
 import com.dnd.namuiwiki.domain.jwt.dto.TokenUserInfoDto;
 import com.dnd.namuiwiki.domain.option.entity.Option;
@@ -9,7 +8,6 @@ import com.dnd.namuiwiki.domain.question.QuestionRepository;
 import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.question.type.QuestionType;
-import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.model.dto.AnswerDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveyRequest;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
@@ -22,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Map;
@@ -44,15 +43,13 @@ class SurveyServiceTest {
     @Mock
     private JwtProvider jwtProvider;
     @Mock
-    private StatisticsService statisticsService;
-    @Mock
-    private DashboardService dashboardService;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     private SurveyService surveyService;
 
     @BeforeEach
     void beforeEach() {
-        surveyService = new SurveyService(userRepository, surveyRepository, questionRepository, jwtProvider, statisticsService, dashboardService);
+        surveyService = new SurveyService(userRepository, surveyRepository, questionRepository, jwtProvider, applicationEventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## 요약
설문 생성 시, Population Statistic과 Dashboard 업데이트를 비동기 이벤트 기반으로 변경하였습니다.

## 변경된 점
- AsyncConfugration 추가
- EventConfiguration 추가
- Survey 생성 완료 시, CreateSurveySuccess 이벤트 발행
- CreateSurveySuccess 핸들러에서 통계 업데이트 실행
- 진행사항 확인할 수 있도록 로깅 추가했습니다.


## 특이 사항

