### PR TITLE
대시보드 및 통계 DB 데이터 초기화 및 재계산(#120)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
@@ -1,8 +1,10 @@
 package com.dnd.namuiwiki.config;
 
+import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
 import com.dnd.namuiwiki.domain.dashboard.DashboardService;
 import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.SurveyEventHandler;
+import com.dnd.namuiwiki.domain.survey.SurveyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,9 +15,12 @@ public class EventConfiguration {
     private final StatisticsService statisticsService;
     private final DashboardService dashboardService;
 
+    private final SurveyRepository surveyRepository;
+    private final DashboardRepository dashboardRepository;
+
     @Bean
     public SurveyEventHandler surveyEventHandler() {
-        return new SurveyEventHandler(statisticsService, dashboardService);
+        return new SurveyEventHandler(statisticsService, dashboardService, surveyRepository, dashboardRepository);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
@@ -2,6 +2,7 @@ package com.dnd.namuiwiki.config;
 
 import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
 import com.dnd.namuiwiki.domain.dashboard.DashboardService;
+import com.dnd.namuiwiki.domain.statistic.StatisticsRepository;
 import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.SurveyEventHandler;
 import com.dnd.namuiwiki.domain.survey.SurveyRepository;
@@ -17,10 +18,12 @@ public class EventConfiguration {
 
     private final SurveyRepository surveyRepository;
     private final DashboardRepository dashboardRepository;
+    private final StatisticsRepository statisticsRepository;
 
     @Bean
     public SurveyEventHandler surveyEventHandler() {
-        return new SurveyEventHandler(statisticsService, dashboardService, surveyRepository, dashboardRepository);
+        return new SurveyEventHandler(statisticsService, dashboardService,
+                surveyRepository, dashboardRepository, statisticsRepository);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyController.java
@@ -57,4 +57,11 @@ public class SurveyController {
         return ResponseDto.ok(response);
     }
 
+    @Operation(hidden = true)
+    @PostMapping("/reset/dashboard")
+    public ResponseEntity<?> resetDashboard(@RequestParam String pwd) {
+        surveyService.resetDashboard(pwd);
+        return ResponseDto.noContent();
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyController.java
@@ -64,4 +64,12 @@ public class SurveyController {
         return ResponseDto.noContent();
     }
 
+
+    @Operation(hidden = true)
+    @PostMapping("/reset/statistics")
+    public ResponseEntity<?> resetStatistics(@RequestParam String pwd) {
+        surveyService.resetStatistics(pwd);
+        return ResponseDto.noContent();
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
@@ -1,8 +1,10 @@
 package com.dnd.namuiwiki.domain.survey;
 
+import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
 import com.dnd.namuiwiki.domain.dashboard.DashboardService;
 import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveySuccessEvent;
+import com.dnd.namuiwiki.domain.survey.model.dto.ResetDashboardEvent;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,8 +14,12 @@ import org.springframework.scheduling.annotation.Async;
 @Slf4j
 @RequiredArgsConstructor
 public class SurveyEventHandler {
+
     private final StatisticsService statisticsService;
     private final DashboardService dashboardService;
+
+    private final SurveyRepository surveyRepository;
+    private final DashboardRepository dashboardRepository;
 
     @Async
     @EventListener
@@ -23,6 +29,17 @@ public class SurveyEventHandler {
 
         dashboardService.updateStatistics(survey);
         statisticsService.updateStatistics(survey);
+    }
+
+    @Async
+    @EventListener
+    public void handleResetDashboardEvent(ResetDashboardEvent event) {
+        log.info("SurveyHandler.handleResetDashboardEvent");
+
+        dashboardRepository.deleteAll();
+        surveyRepository.findAll().forEach(dashboardService::updateStatistics);
+
+        log.info("SurveyHandler.handleResetDashboardEvent done");
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
@@ -2,9 +2,11 @@ package com.dnd.namuiwiki.domain.survey;
 
 import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
 import com.dnd.namuiwiki.domain.dashboard.DashboardService;
+import com.dnd.namuiwiki.domain.statistic.StatisticsRepository;
 import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveySuccessEvent;
 import com.dnd.namuiwiki.domain.survey.model.dto.ResetDashboardEvent;
+import com.dnd.namuiwiki.domain.survey.model.dto.ResetStatisticsEvent;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,7 @@ public class SurveyEventHandler {
 
     private final SurveyRepository surveyRepository;
     private final DashboardRepository dashboardRepository;
+    private final StatisticsRepository statisticsRepository;
 
     @Async
     @EventListener
@@ -40,6 +43,17 @@ public class SurveyEventHandler {
         surveyRepository.findAll().forEach(dashboardService::updateStatistics);
 
         log.info("SurveyHandler.handleResetDashboardEvent done");
+    }
+
+    @Async
+    @EventListener
+    public void handleResetStatisticsEvent(ResetStatisticsEvent event) {
+        log.info("SurveyHandler.handleResetStatisticsEvent");
+
+        statisticsRepository.deleteAll();
+        surveyRepository.findAll().forEach(statisticsService::updateStatistics);
+
+        log.info("SurveyHandler.handleResetStatisticsEvent done");
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -11,12 +11,13 @@ import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.survey.model.dto.AnswerDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveyRequest;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveyResponse;
+import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveySuccessEvent;
 import com.dnd.namuiwiki.domain.survey.model.dto.GetAnswersByQuestionResponse;
 import com.dnd.namuiwiki.domain.survey.model.dto.GetSurveyResponse;
 import com.dnd.namuiwiki.domain.survey.model.dto.ReceivedSurveyDto;
+import com.dnd.namuiwiki.domain.survey.model.dto.ResetDashboardEvent;
 import com.dnd.namuiwiki.domain.survey.model.dto.SentSurveyDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.SingleAnswerWithSurveyDetailDto;
-import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveySuccessEvent;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
 import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
 import com.dnd.namuiwiki.domain.survey.type.AnswerType;
@@ -219,6 +220,14 @@ public class SurveyService {
             survey.setQuestionIdForAnswers();
             surveyRepository.save(survey);
         });
+    }
+
+    public void resetDashboard(String pwd) {
+        if (!SETTING_PASSWORD.equals(pwd)) {
+            throw new ApplicationErrorException(ApplicationErrorType.NO_PERMISSION);
+        }
+
+        applicationEventPublisher.publishEvent(new ResetDashboardEvent());
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -16,6 +16,7 @@ import com.dnd.namuiwiki.domain.survey.model.dto.GetAnswersByQuestionResponse;
 import com.dnd.namuiwiki.domain.survey.model.dto.GetSurveyResponse;
 import com.dnd.namuiwiki.domain.survey.model.dto.ReceivedSurveyDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.ResetDashboardEvent;
+import com.dnd.namuiwiki.domain.survey.model.dto.ResetStatisticsEvent;
 import com.dnd.namuiwiki.domain.survey.model.dto.SentSurveyDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.SingleAnswerWithSurveyDetailDto;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
@@ -228,6 +229,14 @@ public class SurveyService {
         }
 
         applicationEventPublisher.publishEvent(new ResetDashboardEvent());
+    }
+
+    public void resetStatistics(String pwd) {
+        if (!SETTING_PASSWORD.equals(pwd)) {
+            throw new ApplicationErrorException(ApplicationErrorType.NO_PERMISSION);
+        }
+
+        applicationEventPublisher.publishEvent(new ResetStatisticsEvent());
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/ResetDashboardEvent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/ResetDashboardEvent.java
@@ -1,0 +1,4 @@
+package com.dnd.namuiwiki.domain.survey.model.dto;
+
+public class ResetDashboardEvent {
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/ResetStatisticsEvent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/ResetStatisticsEvent.java
@@ -1,0 +1,4 @@
+package com.dnd.namuiwiki.domain.survey.model.dto;
+
+public class ResetStatisticsEvent {
+}


### PR DESCRIPTION
## 요약
대시보드 및 통계 DB 데이터 초기화 및 재계산하는 api 추가하였습니다.

## 변경된 점

## 특이 사항
최대한 기존 코드 수정하지 않도록 surveyController에 엔드포인트 추가하였습니다. 그리고 이미 dashboard와 statistics 모두 의존하고 있는 surveyEventHandler에 해당 내용 추가하였습니다.
