### PR TITLE
feat: 대시보드 조회 시 직접입력 옵션 퍼센트 응답에 포함(#128)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/BestWorthDashboardComponent.java
@@ -2,11 +2,14 @@ package com.dnd.namuiwiki.domain.dashboard.model;
 
 import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.Legend;
 import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 public class BestWorthDashboardComponent extends DashboardComponent {
@@ -25,15 +28,29 @@ public class BestWorthDashboardComponent extends DashboardComponent {
         RatioStatistic bestWorth = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType).get(0);
         Long totalCount = bestWorth.getTotalCount();
 
-        this.rank = bestWorth.getLegends().stream()
-                .map(legend -> {
-                    if (totalCount == 0) {
-                        return new RatioDto(legend.getText(), 0);
-                    }
-                    int percentage = (int) (legend.getCount() * 100 / totalCount);
-                    return new RatioDto(legend.getText(), percentage);
-                })
-                .toList();
+        List<Legend> legends = bestWorth.getLegends();
+        int optionPercentage = 0;
+
+        this.rank = new ArrayList<>();
+
+        for (Legend legend : legends) {
+            if (totalCount == 0) {
+                rank.add(new RatioDto(legend.getText(), 0));
+            }
+            int percentage = (int) (legend.getCount() * 100 / totalCount);
+            optionPercentage += percentage;
+            rank.add(new RatioDto(legend.getText(), percentage));
+        }
+
+        // 직접입력인 legend 인거 찾아서 새로 업데이트
+        updateManualLegendPercentage(optionPercentage);
+    }
+
+    private void updateManualLegendPercentage(int optionPercentage) {
+        Optional<RatioDto> manualLegend = this.rank.stream()
+                .filter(legend -> legend.getLegend().contains("직접 입력"))
+                .findFirst();
+        manualLegend.ifPresent(ratioDto -> ratioDto.setPercentage(100 - optionPercentage));
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/HappyDashboardComponent.java
@@ -2,11 +2,14 @@ package com.dnd.namuiwiki.domain.dashboard.model;
 
 import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.Legend;
 import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 public class HappyDashboardComponent extends DashboardComponent {
@@ -24,15 +27,30 @@ public class HappyDashboardComponent extends DashboardComponent {
     public void calculate(Statistics statistics) {
         RatioStatistic happy = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType).get(0);
         Long totalCount = happy.getTotalCount();
-        this.rank = happy.getLegends().stream()
-                .map(legend -> {
-                    if (totalCount == 0) {
-                        return new RatioDto(legend.getText(), 0);
-                    }
-                    int percentage = (int) (legend.getCount() * 100 / totalCount);
-                    return new RatioDto(legend.getText(), percentage);
-                })
-                .toList();
+
+        List<Legend> legends = happy.getLegends();
+        int optionPercentage = 0;
+
+        this.rank = new ArrayList<>();
+
+        for (Legend legend : legends) {
+            if (totalCount == 0) {
+                rank.add(new RatioDto(legend.getText(), 0));
+            }
+            int percentage = (int) (legend.getCount() * 100 / totalCount);
+            optionPercentage += percentage;
+            rank.add(new RatioDto(legend.getText(), percentage));
+        }
+
+        // 직접입력인 legend 인거 찾아서 새로 업데이트
+        updateManualLegendPercentage(optionPercentage);
+    }
+
+    private void updateManualLegendPercentage(int optionPercentage) {
+        Optional<RatioDto> manualLegend = this.rank.stream()
+                .filter(legend -> legend.getLegend().contains("직접 입력"))
+                .findFirst();
+        manualLegend.ifPresent(ratioDto -> ratioDto.setPercentage(100 - optionPercentage));
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/SadDashboardComponent.java
@@ -2,11 +2,14 @@ package com.dnd.namuiwiki.domain.dashboard.model;
 
 import com.dnd.namuiwiki.domain.dashboard.model.dto.RatioDto;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.statistic.model.Legend;
 import com.dnd.namuiwiki.domain.statistic.model.RatioStatistic;
 import com.dnd.namuiwiki.domain.statistic.model.Statistics;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 public class SadDashboardComponent extends DashboardComponent {
@@ -24,15 +27,30 @@ public class SadDashboardComponent extends DashboardComponent {
     public void calculate(Statistics statistics) {
         RatioStatistic sad = (RatioStatistic) statistics.getStatisticsByDashboardType(this.dashboardType).get(0);
         Long totalCount = sad.getTotalCount();
-        this.rank = sad.getLegends().stream()
-                .map(legend -> {
-                    if (totalCount == 0) {
-                        return new RatioDto(legend.getText(), 0);
-                    }
-                    int percentage = (int) (legend.getCount() * 100 / totalCount);
-                    return new RatioDto(legend.getText(), percentage);
-                })
-                .toList();
+
+        List<Legend> legends = sad.getLegends();
+        int optionPercentage = 0;
+
+        this.rank = new ArrayList<>();
+
+        for (Legend legend : legends) {
+            if (totalCount == 0) {
+                rank.add(new RatioDto(legend.getText(), 0));
+            }
+            int percentage = (int) (legend.getCount() * 100 / totalCount);
+            optionPercentage += percentage;
+            rank.add(new RatioDto(legend.getText(), percentage));
+        }
+
+        // 직접입력인 legend 인거 찾아서 새로 업데이트
+        updateManualLegendPercentage(optionPercentage);
+    }
+
+    private void updateManualLegendPercentage(int optionPercentage) {
+        Optional<RatioDto> manualLegend = this.rank.stream()
+                .filter(legend -> legend.getLegend().contains("직접 입력"))
+                .findFirst();
+        manualLegend.ifPresent(ratioDto -> ratioDto.setPercentage(100 - optionPercentage));
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/RatioDto.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/dto/RatioDto.java
@@ -7,5 +7,9 @@ import lombok.Getter;
 @Getter
 public class RatioDto {
     private final String legend;
-    private final int percentage;
+    private int percentage;
+
+    public void setPercentage(int percentage) {
+        this.percentage = percentage;
+    }
 }


### PR DESCRIPTION
## 요약
대시보드 조회 시 직접입력 옵션 퍼센트 응답에 포함

## 변경된 점
DashboardComponent에서 직접입력 Dto를 찾아 퍼센트를 업데이트합니다.

## 특이 사항

