### PR TITLE
통계 업데이트를 이벤트 기반으로 변경(#92)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/exception/AsyncExceptionHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/common/exception/AsyncExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.dnd.namuiwiki.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("AsyncException message={}, declaringClass={}, methodName={}", ex.getMessage(), method.getDeclaringClass(), method.getName(), ex);
+
+        for (Object param : params) {
+            log.error("Parameter value - {}, declaringClass={}, methodName={}", param, method.getDeclaringClass(), method.getName());
+        }
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
@@ -1,9 +1,24 @@
 package com.dnd.namuiwiki.config;
 
+import com.dnd.namuiwiki.common.exception.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @Configuration
-public class AsyncConfiguration {
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return asyncExceptionHandler();
+    }
+
+    @Bean
+    public AsyncExceptionHandler asyncExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+
 }

--- a/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
@@ -1,0 +1,9 @@
+package com.dnd.namuiwiki.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfiguration {
+}

--- a/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/EventConfiguration.java
@@ -1,0 +1,19 @@
+package com.dnd.namuiwiki.config;
+
+import com.dnd.namuiwiki.domain.statistic.StatisticsService;
+import com.dnd.namuiwiki.domain.survey.SurveyEventHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class EventConfiguration {
+    private final StatisticsService statisticsService;
+
+    @Bean
+    public SurveyEventHandler surveyEventHandler() {
+        return new SurveyEventHandler(statisticsService);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyEventHandler.java
@@ -1,0 +1,25 @@
+package com.dnd.namuiwiki.domain.survey;
+
+import com.dnd.namuiwiki.domain.statistic.StatisticsService;
+import com.dnd.namuiwiki.domain.survey.model.dto.SurveyCreatedEvent;
+import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SurveyEventHandler {
+    private final StatisticsService statisticsService;
+
+    @Async
+    @EventListener
+    public void handleSurveySuccessEvent(SurveyCreatedEvent event) {
+        Survey survey = event.getSurvey();
+        log.info("SurveyEventHandler.handleSurveySuccessEvent: surveyId={}", survey.getId());
+
+        statisticsService.updateStatistics(survey);
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/SurveyCreatedEvent.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/SurveyCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.dnd.namuiwiki.domain.survey.model.dto;
+
+import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SurveyCreatedEvent {
+    private final Survey survey;
+}


### PR DESCRIPTION
## 요약
#121에서 새로 작업된 PR입니다.

설문 생성 시, Dashboard 업데이트를 비동기 이벤트 기반으로 변경하였습니다.


## 변경된 점
- AsyncConfugration 추가
- EventConfiguration 추가
- AsyncExceptionHandler 추가
- Survey 생성 완료 시, SurveyCreatedEvent 이벤트 발행
- SurveyCreatedEvent 핸들러에서 통계 업데이트 실행
- 진행사항 확인할 수 있도록 로깅 추가했습니다.


## 특이 사항

