### PR TITLE
대시보드 업데이트 동시성 해결(#147)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
+++ b/src/main/java/com/dnd/namuiwiki/config/AsyncConfiguration.java
@@ -6,10 +6,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfiguration implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
 
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.namuiwiki.domain.dashboard;
+
+import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.user.entity.User;
+
+import java.util.List;
+
+public interface DashboardCustomRepository {
+    void updateDashboard(User owner, Period period, Relation relation, List<Answer> answers);
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.dnd.namuiwiki.domain.dashboard;
+
+import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DashboardCustomRepositoryImpl implements DashboardCustomRepository {
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void updateDashboard(User owner, Period period, Relation relation, List<Answer> answers) {
+    }
+
+}

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardCustomRepositoryImpl.java
@@ -1,11 +1,16 @@
 package com.dnd.namuiwiki.domain.dashboard;
 
+import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 
 import java.util.List;
 
@@ -15,6 +20,24 @@ public class DashboardCustomRepositoryImpl implements DashboardCustomRepository 
 
     @Override
     public void updateDashboard(User owner, Period period, Relation relation, List<Answer> answers) {
+        Query query = Query.query(Criteria.where("user").is(owner)
+                .and("period").is(period)
+                .and("relation").is(relation));
+
+        Update update = new Update();
+
+        FindAndModifyOptions options = new FindAndModifyOptions().returnNew(true);
+
+        for (Answer answer : answers) {
+            update.inc(String.format("statistics.statistics.%s.totalCount", answer.getQuestion().getId()));
+
+            if (answer.getType().isOption()) {
+                update.inc(String.format("statistics.statistics.%s.legends.%s.count",
+                        answer.getQuestion().getId(), answer.getAnswer().toString()));
+            }
+        }
+
+        mongoTemplate.findAndModify(query, update, options, Dashboard.class);
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 
 public interface DashboardRepository extends MongoRepository<Dashboard, String>, DashboardCustomRepository {
     Optional<Dashboard> findByUserAndPeriodAndRelation(User user, Period period, Relation relation);
+    boolean existsByUserAndPeriodAndRelation(User user, Period period, Relation relation);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface DashboardRepository extends MongoRepository<Dashboard, String> {
+public interface DashboardRepository extends MongoRepository<Dashboard, String>, DashboardCustomRepository {
     Optional<Dashboard> findByUserAndPeriodAndRelation(User user, Period period, Relation relation);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
@@ -9,6 +9,7 @@ import com.dnd.namuiwiki.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @Getter
 @Builder
 @Document("dashboards")
+@CompoundIndex(def = "{ 'user': 1, 'period': 1, 'relation': 1 }", unique = true)
 public class Dashboard extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -30,12 +30,12 @@ public class StatisticsService {
         Period period = survey.getPeriod();
         Relation relation = survey.getRelation();
 
-        var statisticalAnswers = survey.getAnswers().stream()
+        var answers = survey.getAnswers().stream()
                 .filter(answer -> answer.getQuestion().getDashboardType().getStatisticsType().isNotNone())
                 .toList();
 
-        updateDashboards(owner, period, relation, statisticalAnswers);
-        updateBorrowingLimitStatistic(period, relation, statisticalAnswers);
+        updateDashboards(owner, period, relation, answers);
+//        updateBorrowingLimitStatistic(period, relation, statisticalAnswers);
 
     }
 
@@ -50,25 +50,26 @@ public class StatisticsService {
                         .build());
     }
 
-    private void updateDashboards(User owner, Period period, Relation relation, List<Answer> statisticalAnswers) {
-        updateDashboardByCategory(owner, null, null, statisticalAnswers);
-        updateDashboardByCategory(owner, period, null, statisticalAnswers);
-        updateDashboardByCategory(owner, null, relation, statisticalAnswers);
+    private void updateDashboards(User owner, Period period, Relation relation, List<Answer> answers) {
+        updateDashboard(owner, null, null, answers);
+        updateDashboard(owner, period, null, answers);
+        updateDashboard(owner, null, relation, answers);
     }
 
-    private void updateDashboardByCategory(User owner, Period period, Relation relation, List<Answer> answers) {
-        Dashboard dashboard = dashboardRepository.findByUserAndPeriodAndRelation(owner, period, relation)
-                .orElseGet(() -> {
-                    Dashboard newDashboard = Dashboard.builder()
-                            .user(owner)
-                            .period(period)
-                            .relation(relation)
-                            .statistics(Statistics.from(answers.stream().map(Answer::getQuestion).toList()))
-                            .build();
-                    return dashboardRepository.save(newDashboard);
-                });
-        dashboard.updateStatistics(answers);
-        dashboardRepository.save(dashboard);
+    private void updateDashboard(User owner, Period period, Relation relation, List<Answer> answers) {
+        insertDashboardIfNotExist(owner, period, relation, answers);
+        dashboardRepository.updateDashboard(owner, period, relation, answers);
+    }
+
+    private void insertDashboardIfNotExist(User owner, Period period, Relation relation, List<Answer> answers) {
+        if (!dashboardRepository.existsByUserAndPeriodAndRelation(owner, period, relation)) {
+            dashboardRepository.save(Dashboard.builder()
+                    .user(owner)
+                    .period(period)
+                    .relation(relation)
+                    .statistics(Statistics.from(answers.stream().map(Answer::getQuestion).toList()))
+                    .build());
+        }
     }
 
     private void updateBorrowingLimitStatistic(Period period, Relation relation, List<Answer> answers) {

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/StatisticsService.java
@@ -35,8 +35,7 @@ public class StatisticsService {
                 .toList();
 
         updateDashboards(owner, period, relation, answers);
-//        updateBorrowingLimitStatistic(period, relation, statisticalAnswers);
-
+        updateBorrowingLimitStatistic(period, relation, answers);
     }
 
     public PopulationStatistic getPopulationStatistic(Period period, Relation relation, QuestionName questionName) {

--- a/src/test/java/com/dnd/namuiwiki/domain/statistic/StatisticsServiceTest.java
+++ b/src/test/java/com/dnd/namuiwiki/domain/statistic/StatisticsServiceTest.java
@@ -1,0 +1,148 @@
+package com.dnd.namuiwiki.domain.statistic;
+
+import com.dnd.namuiwiki.domain.dashboard.DashboardRepository;
+import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
+import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
+import com.dnd.namuiwiki.domain.option.entity.Option;
+import com.dnd.namuiwiki.domain.question.entity.Question;
+import com.dnd.namuiwiki.domain.question.type.QuestionName;
+import com.dnd.namuiwiki.domain.question.type.QuestionType;
+import com.dnd.namuiwiki.domain.statistic.model.Statistic;
+import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
+import com.dnd.namuiwiki.domain.survey.model.entity.Survey;
+import com.dnd.namuiwiki.domain.survey.type.AnswerType;
+import com.dnd.namuiwiki.domain.survey.type.Period;
+import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("test")
+class StatisticsServiceTest {
+
+    @Autowired
+    StatisticsService statisticsService;
+
+    @Autowired
+    DashboardRepository dashboardRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        dashboardRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("사용자 대시보드 최초 업데이트 시, user와 period/relation 조합의 총 3개의 대시보드가 DB에 존재한다.")
+    void createThreeDashboards() {
+        // given
+        Period period = Period.INFINITE;
+        Relation relation = Relation.ELEMENTARY_SCHOOL;
+        User owner = User.builder().id("testId").wikiId("wikiId").build();
+
+        Survey survey = Survey.builder()
+                .owner(owner)
+                .senderName("김철수")
+                .period(period)
+                .relation(relation)
+                .answers(makeAnswerList())
+                .build();
+
+        // when
+        statisticsService.updateStatistics(survey);
+
+        // then
+        boolean dashboard1 = dashboardRepository.existsByUserAndPeriodAndRelation(owner, null, null);
+        boolean dashboard2 = dashboardRepository.existsByUserAndPeriodAndRelation(owner, period, null);
+        boolean dashboard3 = dashboardRepository.existsByUserAndPeriodAndRelation(owner, null, relation);
+
+        assertThat(dashboard1).isEqualTo(true);
+        assertThat(dashboard2).isEqualTo(true);
+        assertThat(dashboard3).isEqualTo(true);
+
+    }
+
+    @ParameterizedTest
+    @DisplayName("period와 relation 필터 적용하지 않은 대시보드는 설문이 생성되는 수만큼 totalCount가 증가한다.")
+    @ValueSource(ints = {5, 10})
+    void updateTotalCountBySurveySize(int surveySize) throws InterruptedException {
+
+        // given
+        Period period = Period.INFINITE;
+        Relation relation = Relation.ELEMENTARY_SCHOOL;
+        User owner = User.builder().id("testId").wikiId("wikiId").build();
+
+        Survey survey = Survey.builder()
+                .owner(owner)
+                .senderName("김철수")
+                .period(period)
+                .relation(relation)
+                .answers(makeAnswerList())
+                .build();
+
+        // when
+        int numberOfThreads = surveySize - 1;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+
+        statisticsService.updateStatistics(survey);
+        for (int i = 0; i < numberOfThreads; i++) {
+            service.execute(() -> statisticsService.updateStatistics(survey));
+        }
+
+        service.shutdown();
+        boolean finished = service.awaitTermination(1000, TimeUnit.MINUTES);
+
+        assertTrue(finished);
+
+        // then
+        Dashboard dashboard = dashboardRepository.findByUserAndPeriodAndRelation(owner, null, null).orElseThrow();
+        Statistic statistic = dashboard.getStatistics().getStatisticsByDashboardType(DashboardType.BEST_WORTH).get(0);
+
+        Long totalCount = statistic.getTotalCount();
+        assertThat(totalCount).isEqualTo(surveySize);
+
+    }
+
+    private List<Answer> makeAnswerList() {
+
+        Question question1 = Question.builder()
+                .id("questionId1")
+                .type(QuestionType.MULTIPLE_CHOICE)
+                .dashboardType(DashboardType.BEST_WORTH)
+                .options(Map.of("option1", Option.builder().id("option1").build(), "option2", Option.builder().id("option2").build(), "option3", Option.builder().id("option3").build()))
+                .name(QuestionName.CORE_VALUE).build();
+        Object answer = "option1";
+
+        Question question2 = Question.builder()
+                .id("questionId2")
+                .type(QuestionType.NUMERIC_CHOICE)
+                .dashboardType(DashboardType.MONEY)
+                .options(Map.of("option1", Option.builder().id("option1").build(), "option2", Option.builder().id("option2").build(), "option3", Option.builder().id("option3").build()))
+                .name(QuestionName.BORROWING_LIMIT).build();
+        Object answer2 = 11;
+
+        return List.of(
+                Answer.builder().question(question1).type(AnswerType.OPTION).answer(answer).reason("reason").build(),
+                Answer.builder().question(question2).type(AnswerType.MANUAL).answer(answer2).reason("reason").build()
+        );
+    }
+
+}

--- a/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
+++ b/src/test/java/com/dnd/namuiwiki/domain/survey/SurveyServiceTest.java
@@ -9,7 +9,6 @@ import com.dnd.namuiwiki.domain.question.QuestionRepository;
 import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.question.type.QuestionType;
-import com.dnd.namuiwiki.domain.statistic.StatisticsService;
 import com.dnd.namuiwiki.domain.survey.model.dto.AnswerDto;
 import com.dnd.namuiwiki.domain.survey.model.dto.CreateSurveyRequest;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
@@ -22,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Map;
@@ -46,13 +46,13 @@ class SurveyServiceTest {
     @Mock
     private JwtProvider jwtProvider;
     @Mock
-    private StatisticsService statisticsService;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     private SurveyService surveyService;
 
     @BeforeEach
     void beforeEach() {
-        surveyService = new SurveyService(userRepository, surveyRepository, questionRepository, optionRepository, jwtProvider, statisticsService);
+        surveyService = new SurveyService(userRepository, surveyRepository, questionRepository, optionRepository, jwtProvider, applicationEventPublisher);
     }
 
     @Test


### PR DESCRIPTION
## 요약
대시보드 업데이트의 동시성 문제를 `findAndModify` 메소드를 통해 제거하였습니다.


## 변경된 점
- DashboardCustomRepository 추가되었습니다.
  - mongoTemplate을 사용한 메소드 추가되었습니다.
- 통합테스트 코드 작성하였습니다.
- Dashboard에 Index 추가되었습니다  **`<--- 해당 이슈 반영되기 전 DB에 직접 인덱스 생성해주어야 합니다.`**

대시보드 업데이트를 upsert로 수행하려고 했는데, 조건이 까다로워서 반영하지 못했습니다. 
upsert로 수행하지 못할 경우 insert와 update를 분리해야 했고, 이 경우 insert 시 동시성 문제가 발생하여 중복 삽입 가능성이 있습니다. user, period, relation 조건으로 검색한 후 업데이트를 진행하므로 해당 조합으로 인덱스를 생성하여 중복 삽입 방지하였습니다.


## 특이 사항
전체 통계량 업데이트는 현재 이슈와 분리 후 진행하겠습니다.
