### PR TITLE
WikiType Enum 추가

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/entity/Question.java
@@ -5,6 +5,7 @@ import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
 import com.dnd.namuiwiki.domain.option.entity.Option;
 import com.dnd.namuiwiki.domain.question.type.QuestionName;
 import com.dnd.namuiwiki.domain.question.type.QuestionType;
+import com.dnd.namuiwiki.domain.wiki.WikiType;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
@@ -26,6 +27,7 @@ public class Question extends BaseTimeEntity {
     private QuestionType type;
     private DashboardType dashboardType;
     private Long surveyOrder;
+    private WikiType wikiType;
     private boolean reasonRequired;
 
     @DocumentReference(collection = "options")

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Survey.java
@@ -4,6 +4,7 @@ import com.dnd.namuiwiki.common.model.BaseTimeEntity;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
 import com.dnd.namuiwiki.domain.user.entity.User;
+import com.dnd.namuiwiki.domain.wiki.WikiType;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
@@ -35,6 +36,8 @@ public class Survey extends BaseTimeEntity {
     private Relation relation;
 
     private List<Answer> answers;
+
+    private WikiType wikiType;
 
     public Answer getAnswer(int index) {
         return answers.get(index);

--- a/src/main/java/com/dnd/namuiwiki/domain/wiki/WikiType.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/wiki/WikiType.java
@@ -1,0 +1,22 @@
+package com.dnd.namuiwiki.domain.wiki;
+
+public enum WikiType {
+    NAMUI("남의위키", "다른 사람이 보는 내 모습은 어떨까요?"),
+    RAMANCE("연애위키", "연애할 때 나는 어떤 사람인가요?");
+
+    private WikiType(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+
+    private final String title;
+    private final String description;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}


### PR DESCRIPTION
it closes #156 

## 요약
연애 위키 추가에 따라 wikiType enum과 필드 추가되었습니다.

## 변경된 점

- WikiType enum 추가했습니다.
   - 위키에 속한 "질문 개수" 가 화면에서 계속해서 사용되고 있는데, `questionCount`를 넣을까말까 고민을 좀 하였으나.. 일단 넣지 않았습니다. Question 캐시가 적용이 되어 있기도 하고, 추후에 혹시라도 확장성있게 변경된다면 개수를 리터럴하게 코드에 넣어 놓는 것이 걷어내기 힘들지 않을까 싶어서요. 관련해서 의견주세요!
- Survey와 Question Entity에 WikiType 필드 추가했습니다.

```
🚨 PR 머지 후, 아래 쿼리 실행을 통해 survey와 question의 기존 데이터에 wikiType 필드 추가할 예정입니다.

db.surveys.updateMany({}, { $set: { wikiType: "NAMUI" }})
db.questions.updateMany({}, { $set: { wikiType: "NAMUI" }})
```



