### PR TITLE
설문 생성 시 연애 위키 대응

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/common/exception/ApplicationErrorType.java
+++ b/src/main/java/com/dnd/namuiwiki/common/exception/ApplicationErrorType.java
@@ -60,6 +60,7 @@ public enum ApplicationErrorType {
     NOT_STRING_ANSWER(HttpStatus.NOT_FOUND, "문자형 답변이 아닙니다."),
     CANNOT_SEND_SURVEY_TO_MYSELF(HttpStatus.BAD_REQUEST, "자신에게 설문을 보낼 수 없습니다."),
     ANSWER_REASON_REQUIRED(HttpStatus.CONFLICT, "reason 필드가 필요한 질문입니다."),
+    INVALID_ANSWER_TYPE(HttpStatus.BAD_REQUEST, "답변 타입이 다릅니다."),
 
     /**
      * Survey Error Type
@@ -72,7 +73,9 @@ public enum ApplicationErrorType {
     /**
      * Filter Error Type
      */
-    INVALID_FILTER(HttpStatus.BAD_REQUEST, "동시에 두가지 필터를 사용할 수 없습니다.");
+    INVALID_FILTER(HttpStatus.BAD_REQUEST, "동시에 두가지 필터를 사용할 수 없습니다."),
+    INVALID_QUESTION_WIKI_TYPE(HttpStatus.BAD_REQUEST, "질문의 위키 타입이 다릅니다."),
+    ;
 
 
     @Getter

--- a/src/main/java/com/dnd/namuiwiki/domain/question/type/QuestionType.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/type/QuestionType.java
@@ -9,7 +9,7 @@ public enum QuestionType {
     MULTIPLE_CHOICE(List.of(AnswerType.MANUAL, AnswerType.OPTION)),
     SHORT_ANSWER(List.of(AnswerType.MANUAL)),
     NUMERIC_CHOICE(List.of(AnswerType.MANUAL, AnswerType.OPTION)),
-    RANK(List.of(AnswerType.OPTION))
+    RANK(List.of(AnswerType.OPTION_LIST))
     ;
 
     QuestionType(List<AnswerType> answerTypes) {
@@ -28,6 +28,10 @@ public enum QuestionType {
 
     public boolean isNumericType() {
         return this == NUMERIC_CHOICE;
+    }
+
+    public boolean isListType() {
+        return this == RANK;
     }
 
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/question/type/QuestionType.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/question/type/QuestionType.java
@@ -23,7 +23,7 @@ public enum QuestionType {
     }
 
     public boolean isChoiceType() {
-        return this == MULTIPLE_CHOICE || this == OX || this == NUMERIC_CHOICE;
+        return this == MULTIPLE_CHOICE || this == OX || this == NUMERIC_CHOICE || this == RANK;
     }
 
     public boolean isNumericType() {

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyService.java
@@ -56,6 +56,7 @@ public class SurveyService {
         List<Answer> surveyAnswer = request.getAnswers().stream().map(this::convertAnswer).toList();
         Survey survey = surveyRepository.save(Survey.builder()
                 .owner(owner)
+                .wikiType(WikiType.valueOf(request.getWikiType()))
                 .sender(sender)
                 .senderName(request.getSenderName())
                 .period(Period.valueOf(request.getPeriod()))
@@ -74,6 +75,11 @@ public class SurveyService {
         Question question = getQuestionById(answer.getQuestionId());
         AnswerType answerType = AnswerType.valueOf(answer.getType());
         var surveyAnswer = new Answer(question, answerType, answer.getAnswer(), answer.getReason());
+
+        if (answerType.isOptionList()) {
+            List<String> optionIds = (List<String>) answer.getAnswer();
+            optionIds.forEach(optionId -> validateOptionExists(optionId, question));
+        }
 
         if (answerType.isOption()) {
             String optionId = answer.getAnswer().toString();

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/CreateSurveyRequest.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/CreateSurveyRequest.java
@@ -3,6 +3,7 @@ package com.dnd.namuiwiki.domain.survey.model.dto;
 import com.dnd.namuiwiki.common.annotation.Enum;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.wiki.WikiType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -15,6 +16,9 @@ import java.util.List;
 @Getter
 @Builder
 public class CreateSurveyRequest {
+
+    @Enum(enumClass = WikiType.class, ignoreCase = true)
+    private String wikiType;
 
     @NotEmpty
     private String owner;

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 
+import java.lang.reflect.Array;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -33,7 +35,11 @@ public class Answer {
             }
             this.answer = longAnswer;
         } else {
-            validateAnswerObjectType(answer, String.class);
+            if (type.isOptionList()) {
+                validateAnswerObjectType(answer, Array.class);
+            } else {
+                validateAnswerObjectType(answer, String.class);
+            }
             this.answer = answer;
         }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/entity/Answer.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 
-import java.lang.reflect.Array;
+import java.util.List;
 
 @Getter
 @Builder
@@ -36,7 +36,7 @@ public class Answer {
             this.answer = longAnswer;
         } else {
             if (type.isOptionList()) {
-                validateAnswerObjectType(answer, Array.class);
+                validateAnswerObjectType(answer, List.class);
             } else {
                 validateAnswerObjectType(answer, String.class);
             }
@@ -56,7 +56,8 @@ public class Answer {
 
     private void validateAnswerObjectType(Object answer, Class<?> clazz) {
         if (!clazz.isInstance(answer)) {
-            throw new ApplicationErrorException(ApplicationErrorType.NOT_INTEGER_ANSWER);
+            throw new ApplicationErrorException(ApplicationErrorType.INVALID_ANSWER_TYPE,
+                    "예상 타입: " + clazz.getName() + ", 실제 타입: " + answer.getClass().getName());
         }
     }
 

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/type/AnswerType.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/type/AnswerType.java
@@ -1,7 +1,7 @@
 package com.dnd.namuiwiki.domain.survey.type;
 
 public enum AnswerType {
-    MANUAL, OPTION;
+    MANUAL, OPTION, OPTION_LIST;
 
     public boolean isManual() {
         return this == MANUAL;
@@ -9,6 +9,10 @@ public enum AnswerType {
 
     public boolean isOption() {
         return this == OPTION;
+    }
+
+    public boolean isOptionList() {
+        return this == OPTION_LIST;
     }
 
 }


### PR DESCRIPTION
it closes #166 

**이 PR은 #165 가 머지된 후 머지됩니다.**

## 요약
설문 생성 시 연애 위키 대응

## 변경된 점
- 설문 생성 요청 시 wikiType 요청 필드 추가
- 답변의 질문타입과 요청 설문 wikiType이 일치하는지 검증
- RANK 타입에 대해 `OPTION_LIST` AnswerType 추가
