### PR TITLE
feat: DB에 존재하는 대시보드 타입 모두 반환하도록 수정(#178)

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -2,7 +2,10 @@ package com.dnd.namuiwiki.domain.dashboard;
 
 import com.dnd.namuiwiki.common.exception.ApplicationErrorException;
 import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
-import com.dnd.namuiwiki.domain.dashboard.model.*;
+import com.dnd.namuiwiki.domain.dashboard.model.AverageDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.BinaryDashboardComponent;
+import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponentV2;
+import com.dnd.namuiwiki.domain.dashboard.model.RatioDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.dto.DashboardDto;
 import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
 import com.dnd.namuiwiki.domain.dashboard.type.DashboardType;
@@ -24,7 +27,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -39,56 +41,30 @@ public class DashboardService {
 
         User user = findByWikiId(tokenUserInfoDto.getWikiId());
         Optional<Dashboard> dashboard = dashboardRepository.findByUserAndWikiTypeAndPeriodAndRelation(user, wikiType, period, relation);
-        if (dashboard.isEmpty()) {
-            return null;
-        }
-
-
-        if (wikiType.isNamui()) {
-            Stream<DashboardType> namuiDashboardTypes = Stream.of(
-                    DashboardType.BEST_WORTH,
-                    DashboardType.MONEY,
-                    DashboardType.HAPPY,
-                    DashboardType.SAD,
-                    DashboardType.CHARACTER);
-            return convertToDto(namuiDashboardTypes, dashboard, period, relation);
-        } else if (wikiType.isRomance()) {
-            Stream<DashboardType> romanceDashboardTypes = Stream.of(
-                    DashboardType.BUBBLE_CHART,
-                    DashboardType.BAR_CHART,
-                    DashboardType.BINARY,
-                    DashboardType.RANK);
-            return convertToDto(romanceDashboardTypes, dashboard, period, relation);
-        } else {
-            throw new ApplicationErrorException(ApplicationErrorType.INVALID_WIKI_TYPE);
-        }
+        return dashboard.map(value -> convertToDto(value.getStatistics(), period, relation)).orElse(null);
     }
 
-    private DashboardDto convertToDto(Stream<DashboardType> namuiDashboardTypes, Optional<Dashboard> dashboard, Period period, Relation relation) {
+    private DashboardDto convertToDto(Statistics statistics, Period period, Relation relation) {
         List<Question> questions = questionRepository.findAll();
 
-        Statistics statistics = dashboard.get().getStatistics();
-        List<DashboardComponentV2> dashboardComponents = namuiDashboardTypes.flatMap(
-                        dashboardType -> statistics.getStatisticsByDashboardType(dashboardType).stream()
-                                .map(statistic -> {
-                                    Question question = questions.stream()
-                                            .filter(q -> q.getId().equals(statistic.getQuestionId()))
-                                            .findFirst()
-                                            .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_QUESTION_ID));
-                                    if (dashboardType.isBinaryType()) {
-                                        return new BinaryDashboardComponent(statistic, question);
-                                    } else if (dashboardType.isAverageType()) {
-                                        long entireAverage = getEntireAverage(period, relation, question.getName());
-                                        return new AverageDashboardComponent(dashboardType, statistic, entireAverage, question);
-                                    } else if (dashboardType.isRatioType()) {
-                                        return new RatioDashboardComponent(dashboardType, statistic, question);
-                                    } else if (dashboardType.isRankType()) {
-                                        return new RankDashboardComponent(dashboardType, statistic, question);
-                                    } else {
-                                        throw new ApplicationErrorException(ApplicationErrorType.INVALID_DASHBOARD_TYPE);
-                                    }
-                                }))
-                .toList();
+        List<DashboardComponentV2> dashboardComponents = statistics.get().stream()
+                .map(statistic -> {
+                    Question question = questions.stream()
+                            .filter(q -> q.getId().equals(statistic.getQuestionId()))
+                            .findFirst()
+                            .orElseThrow(() -> new ApplicationErrorException(ApplicationErrorType.INVALID_QUESTION_ID));
+                    DashboardType dashboardType = statistic.getDashboardType();
+                    if (dashboardType.isBinaryType()) {
+                        return new BinaryDashboardComponent(statistic, question);
+                    } else if (dashboardType.isAverageType()) {
+                        long entireAverage = getEntireAverage(period, relation, question.getName());
+                        return new AverageDashboardComponent(dashboardType, statistic, entireAverage, question);
+                    } else if (dashboardType.isRatioType()) {
+                        return new RatioDashboardComponent(dashboardType, statistic, question);
+                    } else {
+                        throw new ApplicationErrorException(ApplicationErrorType.INVALID_DASHBOARD_TYPE);
+                    }
+                }).toList();
 
         return new DashboardDto(dashboardComponents);
     }

--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/DashboardService.java
@@ -5,6 +5,7 @@ import com.dnd.namuiwiki.common.exception.ApplicationErrorType;
 import com.dnd.namuiwiki.domain.dashboard.model.AverageDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.BinaryDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.DashboardComponentV2;
+import com.dnd.namuiwiki.domain.dashboard.model.RankDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.RatioDashboardComponent;
 import com.dnd.namuiwiki.domain.dashboard.model.dto.DashboardDto;
 import com.dnd.namuiwiki.domain.dashboard.model.entity.Dashboard;
@@ -61,6 +62,8 @@ public class DashboardService {
                         return new AverageDashboardComponent(dashboardType, statistic, entireAverage, question);
                     } else if (dashboardType.isRatioType()) {
                         return new RatioDashboardComponent(dashboardType, statistic, question);
+                    } else if (dashboardType.isRankType()) {
+                        return new RankDashboardComponent(dashboardType, statistic, question);
                     } else {
                         throw new ApplicationErrorException(ApplicationErrorType.INVALID_DASHBOARD_TYPE);
                     }

--- a/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistics.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/statistic/model/Statistics.java
@@ -17,6 +17,10 @@ import java.util.Optional;
 public class Statistics {
     private Map<String, Statistic> statistics;
 
+    public List<Statistic> get() {
+        return statistics.values().stream().toList();
+    }
+
     public Statistic createAndPut(Question question) {
         StatisticsType statisticsType = question.getDashboardType().getStatisticsType();
         Statistic statistic = Statistic.create(question, statisticsType);


### PR DESCRIPTION
이 PR은 #180 이 머지된 후 머지됩니다.

## 요약
대시보드 타입이 통일됨에 따라, wikiType에 따라서 DB에 존재하는 대시보드 타입 모두 반환하도록 수정합니다.

## 기타 사항

staging에 배포하기 전, DB에 존재하는 dashboardType 수정이 필요합니다.