### PR TITLE
질문별 답변 조회 시 모든 위키 타입에 대해 조회하도록 수정

### DIFF
--- a/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/dashboard/model/entity/Dashboard.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Getter
 @Builder
 @Document("dashboards")
-@CompoundIndex(def = "{ 'user': 1, 'period': 1, 'relation': 1 }", unique = true)
+@CompoundIndex(def = "{ 'user': 1, 'period': 1, 'relation': 1, 'wikiType': 1 }", unique = true)
 public class Dashboard extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/AnswerController.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/AnswerController.java
@@ -35,9 +35,13 @@ public class AnswerController {
             @RequestParam(name = "period", required = false, defaultValue = "TOTAL") Period period,
             @RequestParam(name = "relation", required = false, defaultValue = "TOTAL") Relation relation,
             @RequestParam(name = "pageNo", required = false, defaultValue = "0") int pageNo,
-            @RequestParam(name = "pageSize", required = false, defaultValue = "20") int pageSize) {
-
-        var answersByQuestion = surveyService.getAnswersByQuestion(tokenUserInfoDto.getWikiId(), questionId, period, relation, pageNo, pageSize);
+            @RequestParam(name = "pageSize", required = false, defaultValue = "20") int pageSize
+    ) {
+        var answersByQuestion = surveyService.getAnswersByQuestion(
+                tokenUserInfoDto.getWikiId(), questionId,
+                period, relation,
+                pageNo, pageSize
+        );
         return ResponseDto.ok(answersByQuestion);
     }
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyRepository.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/SurveyRepository.java
@@ -25,5 +25,6 @@ public interface SurveyRepository extends MongoRepository<Survey, String> {
     Page<Survey> findBySenderAndPeriod(User sender, Period period, Pageable pageable);
 
     Page<Survey> findBySenderAndRelation(User sender, Relation relation, Pageable pageable);
+
     Long countByOwnerAndWikiType(User owner, WikiType wikiType);
 }

--- a/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/SingleAnswerWithSurveyDetailDto.java
+++ b/src/main/java/com/dnd/namuiwiki/domain/survey/model/dto/SingleAnswerWithSurveyDetailDto.java
@@ -6,6 +6,7 @@ import com.dnd.namuiwiki.domain.question.entity.Question;
 import com.dnd.namuiwiki.domain.survey.model.entity.Answer;
 import com.dnd.namuiwiki.domain.survey.type.Period;
 import com.dnd.namuiwiki.domain.survey.type.Relation;
+import com.dnd.namuiwiki.domain.wiki.WikiType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,6 +22,7 @@ public class SingleAnswerWithSurveyDetailDto {
     private Object answer;
     private String reason;
     private String optionName;
+    private WikiType wikiType;
 
     public static class SingleAnswerWithSurveyDetailDtoBuilder {
         public SingleAnswerWithSurveyDetailDtoBuilder optionName(Question question, Answer surveyAnswer) {


### PR DESCRIPTION
## 요약
질문별 답변 조회 시 모든 위키 타입에 대해 조회하도록 수정

## 변경된 점
> AS-IS
- 질문별 답변 조회 시에 위키 타입에 따라 Survey에 해당 질문이 없다면 에러 발생

> TO-BE
- 질문별 답변 조회 시 모든 위키 타입에 대해 조회



